### PR TITLE
Pull the MetadataRegistry from OSGI

### DIFF
--- a/metadata/metadata.js
+++ b/metadata/metadata.js
@@ -10,7 +10,7 @@ const osgi = require('../osgi');
 const utils = require('../utils');
 const log = require('../log')('metadata');
 
-let MetadataRegistry = Java.type("org.openhab.core.items.MetadataRegistry");
+let MetadataRegistry = osgi.getService("org.openhab.core.items.MetadataRegistry");
 let Metadata = Java.type("org.openhab.core.items.Metadata");
 let MetadataKey = Java.type("org.openhab.core.items.MetadataKey");
 


### PR DESCRIPTION
The methods we need to interact with the MetadataRegistry are not static. We need to pull an instance of the registry from OSGI to get, set and update metadata.

Signed off by Richard Koshak <rlkoshak@gmail.com>