### PR TITLE
Add math and count operations on groups

### DIFF
--- a/items/managed.js
+++ b/items/managed.js
@@ -26,7 +26,7 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
  * 
  * @memberOf items
  */
- class Item {
+class Item {
     /**
      * Create an Item, wrapping a native Java openHAB Item. Don't use this constructor, instead call {@link getItem}.
      * @param {HostItem} rawItem Java Item from Host
@@ -55,7 +55,7 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * The name of the item.
-     * @return {String} the name
+     * @returns {String} the name
      */
     get name() {
         return this.rawItem.getName();
@@ -63,7 +63,7 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * The label attached to the item
-     * @return {String} the label
+     * @returns {String} the label
      */
     get label() {
         return this.rawItem.getLabel();
@@ -71,7 +71,7 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * The state of the item, as a string.
-     * @return {String} the item's state
+     * @returns {String} the item's state
      */
     get state() {
         return this.rawState.toString();
@@ -79,7 +79,7 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * The raw state of the item, as a java object.
-     * @return {HostState} the item's state
+     * @returns {HostState} the item's state
      */
     get rawState() {
         return this.rawItem.state;
@@ -87,12 +87,10 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * Members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * 
+     * @returns {Item[]} member items
      * @example
      * const group = items.getItem('test_group').members;
      * for (let i = 0; i < group.length; i++) console.log(group[i].label);
-     * 
-     * @returns {Item[]} member items
      */
     get members() {
         return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw));
@@ -116,7 +114,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * Minimum state item of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * 
      * @returns {Item} item with the minimum state
      */
     get membersMin() {
@@ -125,7 +122,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * Maximum state item of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * 
      * @returns {Item} item with the maximum state
      */
     get membersMax() {
@@ -135,7 +131,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
     /**
      * Summarized value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
      * Only includes items of type Number, Dimmer & Rollershutter in calculation.
-     * 
      * @returns {Number} sum of states
      */
     get membersSum() {
@@ -145,7 +140,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
     /**
      * Average value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
      * Only includes items of type Number, Dimmer & Rollershutter in calculation.
-     * 
      * @returns {Number} average of states
      */
     get membersAvg() {
@@ -180,7 +174,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * Minimum state item of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
-     * 
      * @returns {Item} item with the minimum state
      */
     get descendentsMin() {
@@ -189,7 +182,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
 
     /**
      * Maximum state item of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
-     * 
      * @returns {Item} item with the maximum state
      */
     get descendents() {
@@ -199,7 +191,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
     /**
      * Summarized value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
      * Only includes items of type Number, Dimmer & Rollershutter in calculation.
-     * 
      * @returns {Number} sum of states
      */
     get descendentsSum() {
@@ -209,7 +200,6 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
     /**
      * Average value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
      * Only includes items of type Number, Dimmer & Rollershutter in calculation.
-     * 
      * @returns {Number} average of states
      */
     get descendentsAvg() {

--- a/items/managed.js
+++ b/items/managed.js
@@ -26,7 +26,7 @@ const DYNAMIC_ITEM_TAG = "_DYNAMIC_";
  * 
  * @memberOf items
  */
-class Item {
+ class Item {
     /**
      * Create an Item, wrapping a native Java openHAB Item. Don't use this constructor, instead call {@link getItem}.
      * @param {HostItem} rawItem Java Item from Host
@@ -160,6 +160,61 @@ class Item {
      */
     get descendents() {
         return utils.javaSetToJsArray(this.rawItem.getAllMembers()).map(raw => new Item(raw));
+    }
+
+    /**
+     * Names of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * @returns {Array} names of descendent items
+     */
+     get descendentsNames() {
+        return this.descendents.map(item => item.name);
+    }
+
+    /**
+     * Labels of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * @returns {String} states of descendent items as concatenated string
+     */
+    get descendentsLabelsString() {
+        return this.descendents.map(item => item.label).join(', ');
+    }
+
+    /**
+     * Minimum state item of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * 
+     * @returns {Item} item with the minimum state
+     */
+    get descendentsMin() {
+        return this.descendents.reduce((min, item) => parseFloat(item.state) < parseFloat(min.state) ? item : min);
+    }
+
+    /**
+     * Maximum state item of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * 
+     * @returns {Item} item with the maximum state
+     */
+    get descendents() {
+        return this.descendents.reduce((min, item) => parseFloat(item.state) > parseFloat(min.state) ? item : min);
+    }
+
+    /**
+     * Summarized value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * 
+     * @returns {Number} sum of states
+     */
+    get descendentsSum() {
+        return this.descendents.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem').reduce((sum, item) => sum + parseFloat(item.state), 0);
+    }
+
+    /**
+     * Average value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * 
+     * @returns {Number} average of states
+     */
+    get descendentsAvg() {
+        const numbers = this.descendents.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem');
+        return numbers.reduce((avg, item) => { return avg + parseFloat(item.state)/numbers.length; }, 0);
     }
 
     /**

--- a/items/managed.js
+++ b/items/managed.js
@@ -368,6 +368,165 @@ class Item {
     }
 }
 /**
+ * Creates a new item within OpenHab. This item is not registered with any provider.
+ * 
+ * Note that all items created this way have an additional tag attached, for simpler retrieval later. This tag is
+ * created with the value {@link DYNAMIC_ITEM_TAG}.
+ * 
+ * @memberOf items
+ * @param {String} itemName Item name for the Item to create
+ * @param {String} [itemType] the type of the Item
+ * @param {String} [category] the category (icon) for the Item
+ * @param {String[]} [groups] an array of groups the Item is a member of
+ * @param {String} [label] the label for the Item
+ * @param {String[]} [tags] an array of tags for the Item
+ * @param {HostItem} [giBaseType] the group Item base type for the Item
+ * @param {HostGroupFunction} [groupFunction] the group function used by the Item
+ * @param {Map} [itemMetadata] a map of metadata to set on the item
+ */
+ const createItem = function (itemName, itemType, category, groups, label, tags, giBaseType, groupFunction, itemMetadata) {
+    itemName = safeItemName(itemName);
+    
+    let baseItem;
+    if (itemType === 'Group' && typeof giBaseType !== 'undefined') {
+        baseItem = itemBuilderFactory.newItemBuilder(giBaseType, itemName + "_baseItem").build()
+    }
+    
+    if (itemType !== 'Group') {
+        groupFunction = undefined;
+    }
+
+    if (typeof tags === 'undefined') {
+        tags = [];
+    }
+
+    tags.push(DYNAMIC_ITEM_TAG);
+
+    try {
+        var builder = itemBuilderFactory.newItemBuilder(itemType, itemName).
+            withCategory(category).
+            withLabel(label);
+
+        builder = builder.withTags(utils.jsArrayToJavaSet(tags));
+
+        if (typeof groups !== 'undefined') {
+            builder = builder.withGroups(utils.jsArrayToJavaList(groups));
+        }
+
+        if (typeof baseItem !== 'undefined') {
+            builder = builder.withBaseItem(baseItem);
+        }
+        if (typeof groupFunction !== 'undefined') {
+            builder = builder.withGroupFunction(groupFunction);
+        }
+
+        var item = builder.build();
+
+        return new Item(item);
+    } catch (e) {
+        log.error("Failed to create item: " + e);
+        throw e;
+    }
+}
+
+/**
+ * Creates a new item within OpenHab. This item will persist regardless of the lifecycle of the script creating it.
+ * 
+ * Note that all items created this way have an additional tag attached, for simpler retrieval later. This tag is
+ * created with the value {@link DYNAMIC_ITEM_TAG}.
+ * 
+ * @memberOf items
+ * @param {String} itemName Item name for the Item to create
+ * @param {String} [itemType] the type of the Item
+ * @param {String} [category] the category (icon) for the Item
+ * @param {String[]} [groups] an array of groups the Item is a member of
+ * @param {String} [label] the label for the Item
+ * @param {String[]} [tags] an array of tags for the Item
+ * @param {HostItem} [giBaseType] the group Item base type for the Item
+ * @param {HostGroupFunction} [groupFunction] the group function used by the Item
+ */
+const addItem = function (itemName, itemType, category, groups, label, tags, giBaseType, groupFunction) {
+    let item = createItem(...arguments);
+    managedItemProvider.add(item.rawItem);
+    log.debug("Item added: {}", item.name);
+    return item;
+}
+
+/**
+ * Removes an item from OpenHab. The item is removed immediately and cannot be recoved.
+ * 
+ * @memberOf items
+ * @param {String|HostItem} itemOrItemName the item to remove
+ * @returns {Boolean} true iff the item is actually removed
+ */
+const removeItem = function (itemOrItemName) {
+
+    var itemName;
+
+    if (typeof itemOrItemName === 'string') {
+        itemName = itemOrItemName;
+    } else if (itemOrItemName.hasOwnProperty('name')) {
+        itemName = itemOrItemName.name;
+    } else {
+        log.warn('Item not registered (or supplied name is not a string) so cannot be removed');
+        return false;
+    }
+
+    if (typeof getItem(itemName) === 'undefined') {
+        log.warn('Item not registered so cannot be removed');
+        return false;
+    }
+
+    managedItemProvider.remove(itemName);
+
+    if (typeof itemRegistry.getItem(itemName) === 'undefined') {
+        log.debug("Item removed: " + itemName);
+        return true;
+    } else {
+        log.warn("Failed to remove item: " + itemName);
+        return false;
+    }
+}
+
+/**
+ * Replaces (upserts) an item. If an item exists with the same name, it will be removed and a new item with
+ * the supplied parameters will be created in it's place. If an item does not exist with this name, a new
+ * item will be created with the supplied parameters.
+ * 
+ * This function can be useful in scripts which create a static set of items which may need updating either
+ * periodically, during startup or even during development of the script. Using fixed item names will ensure
+ * that the items remain up-to-date, but won't fail with issues related to duplicate items.
+ * 
+ * @memberOf items
+ * @param {String} itemName Item name for the Item to create
+ * @param {String} [itemType] the type of the Item
+ * @param {String} [category] the category (icon) for the Item
+ * @param {String[]} [groups] an array of groups the Item is a member of
+ * @param {String} [label] the label for the Item
+ * @param {String[]} [tags] an array of tags for the Item
+ * @param {HostItem} [giBaseType] the group Item base type for the Item
+ * @param {HostGroupFunction} [groupFunction] the group function used by the Item
+ */
+const replaceItem = function (/* same args as addItem */) {
+    var itemName = arguments[0];
+    try {
+        var item = getItem(itemName);
+        if (typeof item !== 'undefined') {
+            log.debug("Removing existing item " + itemName + "[" + item + "] to replace with updated one");
+            removeItem(itemName);
+        }
+    } catch (e) {
+        if (("" + e).startsWith("org.openhab.core.items.ItemNotFoundException")) {
+            // item not present
+        } else {
+            throw e;
+        }
+    }
+
+    return addItem.apply(this, arguments);
+}
+
+/**
  * Gets an openHAB Item.
  * @memberOf items
  * @param {String} name the name of the item
@@ -389,6 +548,17 @@ const getItem = (name, nullIfMissing = false) => {
 }
 
 /**
+ * Gets all openHAB Items with a specific tag.
+ * 
+ * @memberOf items
+ * @param {String[]} tagNames an array of tags to match against
+ * @return {items.Item[]} the items with a tag that is included in the passed tags
+ */
+const getItemsByTag = (...tagNames) => {
+    return utils.javaSetToJsArray(itemRegistry.getItemsByTag(tagNames)).map(i => new Item(i));
+}
+
+/**
  * Helper function to ensure an item name is valid. All invalid characters are replaced with an underscore.
  * @memberOf items
  * @param {String} s the name to make value
@@ -401,6 +571,11 @@ const safeItemName = s => s.
 module.exports = {
     safeItemName,
     getItem,
+    addItem,
+    getItemsByTag,
+    replaceItem,
+    createItem,
+    removeItem,
     Item,
     /**
      * Custom indexer, to allow static item lookup.

--- a/items/managed.js
+++ b/items/managed.js
@@ -87,10 +87,47 @@ class Item {
 
     /**
      * Members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * 
+     * @example
+     * const group = items.getItem('test_group').members;
+     * for (let i = 0; i < group.length; i++) console.log(group[i].label);
+     * 
      * @returns {Item[]} member items
      */
     get members() {
         return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw));
+    }
+
+    /**
+     * Names of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * @returns {Array} names of member items
+     */
+    getMembersNames() {
+        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).name);
+    }
+
+    /**
+     * Labels of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * @returns {Array} labels of member items
+     */
+    getMembersLabels() {
+        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).label);
+    }
+
+    /**
+     * States of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * @returns {Array} states of member items
+     */
+    getMembersStates() {
+        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).state);
+    }
+
+    /**
+     * Labels of members / children / direct descendents of the current group item (as returned by 'getMembers()') as a concatenated string. Must be a group item.
+     * @returns {String} states of member items as concatenated string
+     */
+     getMembersLabelsString() {
+        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).label).join(', ');
     }
 
     /**
@@ -242,166 +279,6 @@ class Item {
         managedItemProvider.update(this.rawItem);
     }
 }
-
-/**
- * Creates a new item within OpenHab. This item is not registered with any provider.
- * 
- * Note that all items created this way have an additional tag attached, for simpler retrieval later. This tag is
- * created with the value {@link DYNAMIC_ITEM_TAG}.
- * 
- * @memberOf items
- * @param {String} itemName Item name for the Item to create
- * @param {String} [itemType] the type of the Item
- * @param {String} [category] the category (icon) for the Item
- * @param {String[]} [groups] an array of groups the Item is a member of
- * @param {String} [label] the label for the Item
- * @param {String[]} [tags] an array of tags for the Item
- * @param {HostItem} [giBaseType] the group Item base type for the Item
- * @param {HostGroupFunction} [groupFunction] the group function used by the Item
- * @param {Map} [itemMetadata] a map of metadata to set on the item
- */
-const createItem = function (itemName, itemType, category, groups, label, tags, giBaseType, groupFunction, itemMetadata) {
-    itemName = safeItemName(itemName);
-    
-    let baseItem;
-    if (itemType === 'Group' && typeof giBaseType !== 'undefined') {
-        baseItem = itemBuilderFactory.newItemBuilder(giBaseType, itemName + "_baseItem").build()
-    }
-    
-    if (itemType !== 'Group') {
-        groupFunction = undefined;
-    }
-
-    if (typeof tags === 'undefined') {
-        tags = [];
-    }
-
-    tags.push(DYNAMIC_ITEM_TAG);
-
-    try {
-        var builder = itemBuilderFactory.newItemBuilder(itemType, itemName).
-            withCategory(category).
-            withLabel(label);
-
-        builder = builder.withTags(utils.jsArrayToJavaSet(tags));
-
-        if (typeof groups !== 'undefined') {
-            builder = builder.withGroups(utils.jsArrayToJavaList(groups));
-        }
-
-        if (typeof baseItem !== 'undefined') {
-            builder = builder.withBaseItem(baseItem);
-        }
-        if (typeof groupFunction !== 'undefined') {
-            builder = builder.withGroupFunction(groupFunction);
-        }
-
-        var item = builder.build();
-
-        return new Item(item);
-    } catch (e) {
-        log.error("Failed to create item: " + e);
-        throw e;
-    }
-}
-
-/**
- * Creates a new item within OpenHab. This item will persist regardless of the lifecycle of the script creating it.
- * 
- * Note that all items created this way have an additional tag attached, for simpler retrieval later. This tag is
- * created with the value {@link DYNAMIC_ITEM_TAG}.
- * 
- * @memberOf items
- * @param {String} itemName Item name for the Item to create
- * @param {String} [itemType] the type of the Item
- * @param {String} [category] the category (icon) for the Item
- * @param {String[]} [groups] an array of groups the Item is a member of
- * @param {String} [label] the label for the Item
- * @param {String[]} [tags] an array of tags for the Item
- * @param {HostItem} [giBaseType] the group Item base type for the Item
- * @param {HostGroupFunction} [groupFunction] the group function used by the Item
- */
-const addItem = function (itemName, itemType, category, groups, label, tags, giBaseType, groupFunction) {
-    let item = createItem(...arguments);
-    managedItemProvider.add(item.rawItem);
-    log.debug("Item added: {}", item.name);
-    return item;
-}
-
-/**
- * Removes an item from OpenHab. The item is removed immediately and cannot be recoved.
- * 
- * @memberOf items
- * @param {String|HostItem} itemOrItemName the item to remove
- * @returns {Boolean} true iff the item is actually removed
- */
-const removeItem = function (itemOrItemName) {
-
-    var itemName;
-
-    if (typeof itemOrItemName === 'string') {
-        itemName = itemOrItemName;
-    } else if (itemOrItemName.hasOwnProperty('name')) {
-        itemName = itemOrItemName.name;
-    } else {
-        log.warn('Item not registered (or supplied name is not a string) so cannot be removed');
-        return false;
-    }
-
-    if (typeof getItem(itemName) === 'undefined') {
-        log.warn('Item not registered so cannot be removed');
-        return false;
-    }
-
-    managedItemProvider.remove(itemName);
-
-    if (typeof itemRegistry.getItem(itemName) === 'undefined') {
-        log.debug("Item removed: " + itemName);
-        return true;
-    } else {
-        log.warn("Failed to remove item: " + itemName);
-        return false;
-    }
-}
-
-/**
- * Replaces (upserts) an item. If an item exists with the same name, it will be removed and a new item with
- * the supplied parameters will be created in it's place. If an item does not exist with this name, a new
- * item will be created with the supplied parameters.
- * 
- * This function can be useful in scripts which create a static set of items which may need updating either
- * periodically, during startup or even during development of the script. Using fixed item names will ensure
- * that the items remain up-to-date, but won't fail with issues related to duplicate items.
- * 
- * @memberOf items
- * @param {String} itemName Item name for the Item to create
- * @param {String} [itemType] the type of the Item
- * @param {String} [category] the category (icon) for the Item
- * @param {String[]} [groups] an array of groups the Item is a member of
- * @param {String} [label] the label for the Item
- * @param {String[]} [tags] an array of tags for the Item
- * @param {HostItem} [giBaseType] the group Item base type for the Item
- * @param {HostGroupFunction} [groupFunction] the group function used by the Item
- */
-const replaceItem = function (/* same args as addItem */) {
-    var itemName = arguments[0];
-    try {
-        var item = getItem(itemName);
-        if (typeof item !== 'undefined') {
-            log.debug("Removing existing item " + itemName + "[" + item + "] to replace with updated one");
-            removeItem(itemName);
-        }
-    } catch (e) {
-        if (("" + e).startsWith("org.openhab.core.items.ItemNotFoundException")) {
-            // item not present
-        } else {
-            throw e;
-        }
-    }
-
-    return addItem.apply(this, arguments);
-}
-
 /**
  * Gets an openHAB Item.
  * @memberOf items
@@ -424,17 +301,6 @@ const getItem = (name, nullIfMissing = false) => {
 }
 
 /**
- * Gets all openHAB Items with a specific tag.
- * 
- * @memberOf items
- * @param {String[]} tagNames an array of tags to match against
- * @return {items.Item[]} the items with a tag that is included in the passed tags
- */
-const getItemsByTag = (...tagNames) => {
-    return utils.javaSetToJsArray(itemRegistry.getItemsByTag(tagNames)).map(i => new Item(i));
-}
-
-/**
  * Helper function to ensure an item name is valid. All invalid characters are replaced with an underscore.
  * @memberOf items
  * @param {String} s the name to make value
@@ -447,11 +313,6 @@ const safeItemName = s => s.
 module.exports = {
     safeItemName,
     getItem,
-    addItem,
-    getItemsByTag,
-    replaceItem,
-    createItem,
-    removeItem,
     Item,
     /**
      * Custom indexer, to allow static item lookup.

--- a/items/managed.js
+++ b/items/managed.js
@@ -88,9 +88,6 @@ class Item {
     /**
      * Members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
      * @returns {Item[]} member items
-     * @example
-     * const group = items.getItem('test_group').members;
-     * for (let i = 0; i < group.length; i++) console.log(group[i].label);
      */
     get members() {
         return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw));
@@ -130,20 +127,20 @@ class Item {
 
     /**
      * Summarized value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} sum of states
      */
     get membersSum() {
-        return this.members.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem').reduce((sum, item) => sum + parseFloat(item.state), 0);
+        return this.members.filter(item => (item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem') && !item.isUninitialized).reduce((sum, item) => sum + parseFloat(item.state), 0);
     }
 
     /**
      * Average value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} average of states
      */
     get membersAvg() {
-        const numbers = this.members.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem');
+        const numbers = this.members.filter(item => (item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem') && !item.isUninitialized);
         return numbers.reduce((avg, item) => { return avg + parseFloat(item.state)/numbers.length; }, 0);
     }
 
@@ -190,20 +187,20 @@ class Item {
 
     /**
      * Summarized value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} sum of states
      */
     get descendentsSum() {
-        return this.descendents.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem').reduce((sum, item) => sum + parseFloat(item.state), 0);
+        return this.descendents.filter(item => (item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem') && !item.isUninitialized).reduce((sum, item) => sum + parseFloat(item.state), 0);
     }
 
     /**
      * Average value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} average of states
      */
     get descendentsAvg() {
-        const numbers = this.descendents.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem');
+        const numbers = this.descendents.filter(item => (item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem') && !item.isUninitialized);
         return numbers.reduce((avg, item) => { return avg + parseFloat(item.state)/numbers.length; }, 0);
     }
 
@@ -221,6 +218,28 @@ class Item {
         } else {
             return false;
         }
+    }
+
+    /**
+     * Count the number of members / children / direct descendents of the current group item (as returned by 'getMembers()') matching a comparison. Must be a group item.
+     * @param {String} compareFunc comparison function
+     * @returns {Number} number of matches
+     * @example
+     * items.getItem('group').membersCount(item => item.state === 'ON');
+     */
+    membersCount(compareFunc) {
+        return this.members.filter(compareFunc).length;
+    }
+
+    /**
+     * Count the number of all descendents of the current group item (as returned by 'getAllMembers()') matching a comparison. Must be a group item.
+     * @param {String} compareFunc comparison function
+     * @returns {Number} number of matches
+     * @example
+     * items.getItem('group').descendentsCount(item => item.state === 'ON');
+     */
+    descendentsCount(compareFunc) {
+        return this.descendents.filter(compareFunc).length;
     }
 
     /**

--- a/items/managed.js
+++ b/items/managed.js
@@ -47,7 +47,7 @@ class Item {
 
     /**
      * The type of the item: the Simple (without package) name of the Java item type, such as 'Switch'.
-     * @return {String} the type
+     * @returns {String} the type
      */
     get type() {
         return this.rawItem.getClass().getSimpleName();
@@ -532,7 +532,7 @@ const replaceItem = function (/* same args as addItem */) {
  * @memberOf items
  * @param {String} name the name of the item
  * @param {String} nullIfMissing whether to return null if the item cannot be found (default is to throw an exception)
- * @return {items.Item} the item
+ * @returns {items.Item} the item
  */
 const getItem = (name, nullIfMissing = false) => {
     try {
@@ -553,7 +553,7 @@ const getItem = (name, nullIfMissing = false) => {
  * 
  * @memberOf items
  * @param {String[]} tagNames an array of tags to match against
- * @return {items.Item[]} the items with a tag that is included in the passed tags
+ * @returns {items.Item[]} the items with a tag that is included in the passed tags
  */
 const getItemsByTag = (...tagNames) => {
     return utils.javaSetToJsArray(itemRegistry.getItemsByTag(tagNames)).map(i => new Item(i));

--- a/items/managed.js
+++ b/items/managed.js
@@ -103,7 +103,7 @@ class Item {
      * @returns {Array} names of member items
      */
     get membersNames() {
-        return this.members.map(raw => raw.name);
+        return this.members.map(item => item.name);
     }
 
     /**
@@ -111,24 +111,48 @@ class Item {
      * @returns {String} states of member items as concatenated string
      */
     get membersLabelsString() {
-        return this.members.map(raw => raw.label).join(', ');
+        return this.members.map(item => item.label).join(', ');
     }
 
     /**
-     * States of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * @returns {Array} states of member items
+     * Minimum state item of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * 
+     * @returns {Item} item with the minimum state
      */
-    getMembersStates() {
-        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).state);
+    get membersMin() {
+        return this.members.reduce((min, item) => parseFloat(item.state) < parseFloat(min.state) ? item : min);
     }
 
     /**
-     * Labels of members / children / direct descendents of the current group item (as returned by 'getMembers()') as a concatenated string. Must be a group item.
-     * @returns {String} states of member items as concatenated string
+     * Maximum state item of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * 
+     * @returns {Item} item with the maximum state
      */
-     getMembersLabelsString() {
-        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).label).join(', ');
+    get membersMax() {
+        return this.members.reduce((min, item) => parseFloat(item.state) > parseFloat(min.state) ? item : min);
     }
+
+    /**
+     * Summarized value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * 
+     * @returns {Number} sum of states
+     */
+    get membersSum() {
+        return this.members.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem').reduce((sum, item) => sum + parseFloat(item.state), 0);
+    }
+
+    /**
+     * Average value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * Only includes items of type Number, Dimmer & Rollershutter in calculation.
+     * 
+     * @returns {Number} average of states
+     */
+    get membersAvg() {
+        const numbers = this.members.filter(item => item.type === 'NumberItem' || item.type === 'DimmerItem' || item.type === 'RollershutterItem');
+        return numbers.reduce((avg, item) => { return avg + parseFloat(item.state)/numbers.length; }, 0);
+    }
+
 
     /**
      * All descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.

--- a/items/managed.js
+++ b/items/managed.js
@@ -367,6 +367,7 @@ class Item {
         managedItemProvider.update(this.rawItem);
     }
 }
+
 /**
  * Creates a new item within OpenHab. This item is not registered with any provider.
  * 
@@ -384,7 +385,7 @@ class Item {
  * @param {HostGroupFunction} [groupFunction] the group function used by the Item
  * @param {Map} [itemMetadata] a map of metadata to set on the item
  */
- const createItem = function (itemName, itemType, category, groups, label, tags, giBaseType, groupFunction, itemMetadata) {
+const createItem = function (itemName, itemType, category, groups, label, tags, giBaseType, groupFunction, itemMetadata) {
     itemName = safeItemName(itemName);
     
     let baseItem;

--- a/items/managed.js
+++ b/items/managed.js
@@ -102,16 +102,16 @@ class Item {
      * Names of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
      * @returns {Array} names of member items
      */
-    getMembersNames() {
-        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).name);
+    get membersNames() {
+        return this.members.map(raw => raw.name);
     }
 
     /**
-     * Labels of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * @returns {Array} labels of member items
+     * Labels of members / children / direct descendents of the current group item (as returned by 'getMembers()') as a concatenated string. Must be a group item.
+     * @returns {String} states of member items as concatenated string
      */
-    getMembersLabels() {
-        return utils.javaSetToJsArray(this.rawItem.getMembers()).map(raw => new Item(raw).label);
+    get membersLabelsString() {
+        return this.members.map(raw => raw.label).join(', ');
     }
 
     /**

--- a/items/managed.js
+++ b/items/managed.js
@@ -111,23 +111,25 @@ class Item {
 
     /**
      * Minimum state item of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * Filters for items not {@link isUninitialized}.
      * @returns {Item} item with the minimum state
      */
     get membersMin() {
-        return this.members.reduce((min, item) => parseFloat(item.state) < parseFloat(min.state) ? item : min);
+        return this.members.filter(item => !item.isUninitialized).reduce((min, item) => parseFloat(item.state) < parseFloat(min.state) ? item : min);
     }
 
     /**
      * Maximum state item of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
+     * Filters for items not {@link isUninitialized}.
      * @returns {Item} item with the maximum state
      */
     get membersMax() {
-        return this.members.reduce((min, item) => parseFloat(item.state) > parseFloat(min.state) ? item : min);
+        return this.members.filter(item => !item.isUninitialized).reduce((min, item) => parseFloat(item.state) > parseFloat(min.state) ? item : min);
     }
 
     /**
      * Summarized value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
+     * Filters for items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} sum of states
      */
     get membersSum() {
@@ -136,7 +138,7 @@ class Item {
 
     /**
      * Average value of members / children / direct descendents of the current group item (as returned by 'getMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
+     * Filters for items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} average of states
      */
     get membersAvg() {
@@ -171,23 +173,25 @@ class Item {
 
     /**
      * Minimum state item of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * Filters for items not {@link isUninitialized}.
      * @returns {Item} item with the minimum state
      */
     get descendentsMin() {
-        return this.descendents.reduce((min, item) => parseFloat(item.state) < parseFloat(min.state) ? item : min);
+        return this.descendents.filter(item => !item.isUninitialized).reduce((min, item) => parseFloat(item.state) < parseFloat(min.state) ? item : min);
     }
 
     /**
      * Maximum state item of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
+     * Filters for items not {@link isUninitialized}.
      * @returns {Item} item with the maximum state
      */
     get descendents() {
-        return this.descendents.reduce((min, item) => parseFloat(item.state) > parseFloat(min.state) ? item : min);
+        return this.descendents.filter(item => !item.isUninitialized).reduce((min, item) => parseFloat(item.state) > parseFloat(min.state) ? item : min);
     }
 
     /**
      * Summarized value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
+     * Filters for items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} sum of states
      */
     get descendentsSum() {
@@ -196,7 +200,7 @@ class Item {
 
     /**
      * Average value of all descendents of the current group item (as returned by 'getAllMembers()'). Must be a group item.
-     * Only includes items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
+     * Filters for items of type Number, Dimmer & Rollershutter in calculation and not {@link isUninitialized}.
      * @returns {Number} average of states
      */
     get descendentsAvg() {


### PR DESCRIPTION
@digitaldan 
This PR includes most parts of the [groupUtils](https://github.com/rkoshak/openhab-rules-tools/tree/main/group_utils) from @rkoshak 's [openhab-rules-tools](https://github.com/rkoshak/openhab-rules-tools) in the helper library.
NOTE: I am the author of them, so copyright is no problem.

It includes:

- Get an array of only the names of the group members. Useful for iterating on group members.
- Get a concatenated string of the members' labels. Useful for UI and notifications.
- Get the member item with the minimum or maximum state.
- Get the avg or sum of members' states. (A filter for !`isUninitialized` and Item types Number, Dimmer & Rollershutter is applied).
- Cound how many members match a given comparison function.

I also fixed some typos in the JSDoc comments.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>