### PR TITLE
Added key to the getMetadataValue to be able to read namespace config…

### DIFF
--- a/items/managed.js
+++ b/items/managed.js
@@ -120,10 +120,11 @@ class Item {
     /**
      * Gets metadata values for this item.
      * @param {String} namespace The namespace for the metadata to retreive
+     * @param {String} key The configuration key of the given namespace to retrieve
      * @returns {String} the metadata associated with this item and namespace
      */
-    getMetadataValue(namespace) {
-        return metadata.getValue(this.name, namespace);
+    getMetadataValue(namespace, key) {
+        return metadata.getValue(this.name, namespace, key);
     }
 
     /**

--- a/metadata/metadata.js
+++ b/metadata/metadata.js
@@ -22,11 +22,12 @@ let MetadataKey = Java.type("org.openhab.core.items.MetadataKey");
  * @memberof metadata
  * @param {String} name of the Item
  * @param {String} namespace name of the namespace
+ * @param {String} key configuration key of the namespace
  * @returns {String|null} the metadata as a string, or null
  */
-let getValue = function(itemName, namespace) {
+let getValue = function(itemName, namespace, key) {
     let result = MetadataRegistry.get(new MetadataKey(namespace, itemName));
-    return result ? result.value : null;
+    return result ? (key ? (result.configuration.containsKey(key) ? result.configuration[key] : null) : item.value) : null;
 };
 
 let addValue = function(itemName, namespace, value) {


### PR DESCRIPTION
I was experimenting with the JS Scripting and found out that the Item has missing the ability to read the metadata configuration value - might be useful in rules such as Times of the Day.

This PR extends the `Item.GetMetadataValue` method to accept `key` of the configuration value within the given `namespace` - if not specified the metadata namespace value will be returned as before.