### PR TITLE
Add frontmatter for better organization wide processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: openHAB Javascript Library
+source: https://github.com/openhab/openhab-js/blob/main/README.md
+description: "Fairly high-level ES6 library to support automation in openHAB. It provides convenient access to common openHAB functionality within rules including items, things, actions, logging and more."
+---
+
 # openHAB Javascript Library
 [![Build
 Status](https://github.com/openhab/openhab-js/actions/workflows/build.yaml/badge.svg)](https://github.com/openhab/openhab-js/actions/workflows/build.yaml) [![npm version](https://badge.fury.io/js/openhab.svg)](https://badge.fury.io/js/openhab)


### PR DESCRIPTION
This will ad a frontmatter part to the readme file, which provides useful metadata for the website builds.

I am assuming that the openhab-addons repository gets updated autoamtically from here.
Please correct me if i am wrong.

This will also redirect possible doc contributors to the correct file through the frontmatters `source` property, which we use to build up the dynamic `Edit this page on GitHub` links at the bottom of each docs article.

## To clarify

I tried to get into the repo but i am not sure if the doc sxripts affect this file or only copy it.
