### PR TITLE
Fix create of Trigger with old state (from)

### DIFF
--- a/triggers.js
+++ b/triggers.js
@@ -68,7 +68,7 @@ module.exports = {
     ItemStateChangeTrigger: (itemName, oldState, newState, triggerName) => createTrigger("core.ItemStateChangeTrigger", triggerName, {
         "itemName": itemName,
         "state": newState,
-        "oldState": oldState
+        "previousState": oldState
     }),
 
     /**
@@ -84,8 +84,8 @@ module.exports = {
      * @param {String} [triggerName] the name of the trigger to create
      */
     ItemStateUpdateTrigger: (itemName, state, triggerName) => createTrigger("core.ItemStateUpdateTrigger", triggerName, {
-            "itemName": itemName,
-            "state": state
+        "itemName": itemName,
+        "state": state
     }),    
 
     /**
@@ -121,7 +121,7 @@ module.exports = {
     GroupStateChangeTrigger: (groupName, oldState, newState, triggerName) => createTrigger("core.GroupStateChangeTrigger", triggerName, {
         "groupName": groupName,
         "state": newState,
-        "oldState": oldState
+        "previousState": oldState
     }),
 
     /**


### PR DESCRIPTION
The configuration parameter in the StateChangeTrigger is named 'previousState' and not 'oldState'.
'oldState' is the value in the event, but should not be used to construct the trigger.
See https://github.com/openhab/openhab-core/blob/cabb3f73150d13f44d647f46af8362e396684b92/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateTriggerHandler.java#L67
