### PR TITLE
ItemHistory: Remove debug logging & gitignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 out
 dist
 docs
+.vscode

--- a/items/item-history.js
+++ b/items/item-history.js
@@ -89,7 +89,6 @@ class ItemHistory {
      * @returns {(Date | null)}
      */
     lastUpdate(serviceId) {
-        console.log("Last Update", ...arguments);
         return this._dateOrNull(PersistenceExtensions.lastUpdate(this.item, ...arguments));
     }
 


### PR DESCRIPTION
Fixes #55 where call of `item.history` causes logging every time.

Additionally, adds the `.vscode` directory to gitignore.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>