### PR TITLE
getTriggeredData shall deliver "module" (triggerName) 

### DIFF
--- a/rules/rules.js
+++ b/rules/rules.js
@@ -275,7 +275,8 @@ const getTriggeredData = function (input) {
             receivedCommand: event.getItemCommand(),
             oldState: input.get("oldState") + "",
             newState: input.get("newState") + "",
-            itemName: event.getItemName()
+            itemName: event.getItemName(),
+            module: input.get("module")
         }
     }
 
@@ -297,7 +298,8 @@ const getTriggeredData = function (input) {
         receivedCommand: null,
         receivedState: null,
         receivedTrigger: null,
-        itemName: evArr[0]
+        itemName: evArr[0],
+        module: input.get("module")
     };
 
     try {

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -336,6 +336,7 @@ const getTriggeredData = function (input) {
                 d.eventType = "time";
                 d.triggerType = "GenericCronTrigger";
                 d.triggerTypeOld = "TimerTrigger";
+                d.module = "CRON";
             } else {
                 d.eventType = "";
                 d.triggerType = "";

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -332,11 +332,11 @@ const getTriggeredData = function (input) {
             d.receivedTrigger = evArr[2];
             break;
         default:
+            d.module = "";
             if (input.size() == 0) {
                 d.eventType = "time";
                 d.triggerType = "GenericCronTrigger";
                 d.triggerTypeOld = "TimerTrigger";
-                d.module = "CRON";
             } else {
                 d.eventType = "";
                 d.triggerType = "";

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -332,7 +332,6 @@ const getTriggeredData = function (input) {
             d.receivedTrigger = evArr[2];
             break;
         default:
-            d.module = "";
             if (input.size() == 0) {
                 d.eventType = "time";
                 d.triggerType = "GenericCronTrigger";


### PR DESCRIPTION
getTriggeredData shall return also the module name, (the trigger name supplied at creation time)

This would make it possible to have supply names to the triggers, e.g.:

```
trig.push(triggers.GenericCronTrigger("0 0/1 * 1/1 * ? *", "CRON"))
trig.push(triggers.ChannelEventTrigger('homematic:HmIP-SMI55:3014F711A0001F5A4993FA84:0014D709AEF7C0:1#BUTTON', 'SHORT_PRESSED', "OPT1"))
trig.push(triggers.ChannelEventTrigger('homematic:HmIP-SMI55:3014F711A0001F5A4993FA84:0014D709AEF7C0:2#BUTTON', 'SHORT_PRESSED', "OPT2"))

```
and the easy do evaluate at the execute which triggers is executed:

```
rules.JSRule({
  name: "Test Rule",
  description: "Firste test for migration from Jython to JS",
  triggers: trig,
  execute: module => {
    switch (module["module"]) {
        case "CRON":
             ...
            break;
        case "OPT1":
             ...
            break;
        case "OPT2":
             ...
            break;
    }

  }
});

```