### PR TITLE
Fix throw Error

### DIFF
--- a/rules/operation-builder.js
+++ b/rules/operation-builder.js
@@ -417,7 +417,7 @@ class ToggleOperation extends OperationConfig {
                 break;
             }
             default:
-                throw error(`Toggle not supported for items of type ${item.type}`);
+                throw Error(`Toggle not supported for items of type ${item.type}`);
         }
     }
 }
@@ -433,7 +433,7 @@ class TimingItemStateOperation extends OperationConfig {
     constructor(operationBuilder, item_changed_trigger_config, duration) {
         super(operationBuilder);
         if (typeof item_changed_trigger_config.to_value === 'undefined') {
-            throw error("Must specify item state value to wait for!");
+            throw Error("Must specify item state value to wait for!");
         }
 
         this.item_changed_trigger_config = item_changed_trigger_config;
@@ -453,7 +453,7 @@ class TimingItemStateOperation extends OperationConfig {
             case "changed":
                 return [triggers.ChangedEventTrigger(this.item_name)];
             default:
-                throw error("Unknown operation type: " + this.op_type);
+                throw Error("Unknown operation type: " + this.op_type);
         }
     }
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -150,8 +150,7 @@ let JSRule = function (ruleConfig) {
         try {
             return ruleConfig.execute(getTriggeredData(input));
         } catch (error) {
-            log.error(`Failed to execute rule ${ruid}: ${error}: ${error.stack}`);
-            throw error;
+            throw Error(`Failed to execute rule ${ruid}: ${error}: ${error.stack}`);
         }
     };
 

--- a/rules/trigger-builder.js
+++ b/rules/trigger-builder.js
@@ -327,7 +327,7 @@ class ItemTriggerConfig extends TriggerConf {
             case "receivedUpdate":
                 return compact ? `${this.item_name}/↻` : `${this.type} ${this.item_name} received update`;
             default:
-                throw error("Unknown operation type: " + this.op_type);
+                throw Error("Unknown operation type: " + this.op_type);
         }
     }
 
@@ -341,7 +341,7 @@ class ItemTriggerConfig extends TriggerConf {
                 case 'receivedUpdate':
                     return [triggers.GroupStateUpdateTrigger(this.item_name, this.to_value)]
                 default:
-                    throw error("Unknown operation type: " + this.op_type);
+                    throw Error("Unknown operation type: " + this.op_type);
             }
         } else {
             switch (this.op_type) {
@@ -352,7 +352,7 @@ class ItemTriggerConfig extends TriggerConf {
                 case 'receivedUpdate':
                     return [triggers.ItemStateUpdateTrigger(this.item_name, this.to_value)]
                 default:
-                    throw error("Unknown operation type: " + this.op_type);
+                    throw Error("Unknown operation type: " + this.op_type);
             }
         }
     }
@@ -410,7 +410,7 @@ class ThingTriggerConfig extends TriggerConf {
             case "updated":
                 return compact ? `${this.thingUID}/updated` : `Thing ${this.thingUID} received update`;
             default:
-                throw error("Unknown operation type: " + this.op_type);
+                throw Error("Unknown operation type: " + this.op_type);
         }
     }
 
@@ -464,7 +464,7 @@ class ThingTriggerConfig extends TriggerConf {
             case 'updated':
                 return [triggers.ThingStatusUpdateTrigger(this.thingUID, this.to_value)]
             default:
-                throw error("Unknown operation type: " + this.op_type);
+                throw Error("Unknown operation type: " + this.op_type);
         }
     }
 };

--- a/utils.js
+++ b/utils.js
@@ -87,7 +87,7 @@ let dumpObject = function (obj) {
 
 let isJsInstanceOfJava = function(instance, type) {
     if(!Java.isType(type)) {
-        throw error("type is not a java class");
+        throw Error("type is not a java class");
     }
 
     if(instance === null || instance === undefined || instance.class === null || instance.class === undefined) {


### PR DESCRIPTION
Fixes #79.

Instead of `throw Error` sometimes `throw error` was used,
which led to reference errors.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>