### PR TITLE
Cache: Check whether key exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ See [openhab-js : cache](https://openhab.github.io/openhab-js/cache.html) for fu
     * .get(key, defaultSupplier) ⇒ <code>Object | null</code>
     * .put(key, value) ⇒ <code>Previous Object | null</code>
     * .remove(key) ⇒ <code>Previous Object | null</code>
+    * .exists(key) ⇒ <code>boolean</code>
 
 The `defaultSupplier` provided function will return a default value if a specified key is not already associated with a value
 

--- a/cache.js
+++ b/cache.js
@@ -5,7 +5,7 @@
  * @namespace cache
  */
 
-const cache = require("@runtime").sharedcache
+const cache = require("@runtime").sharedcache;
 
 /**
  * Returns the value to which the specified key is mapped
@@ -27,13 +27,13 @@ const cache = require("@runtime").sharedcache
  * @param {function} [defaultSupplier] if the specified key is not already associated with a value, this function will return a default value
  * @returns {(*|null)} the current object for the supplied key, a default value if defaultSupplier is provided, or null
  */
-let get = function (key, defaultSupplier) {
+const get = function (key, defaultSupplier) {
     if (typeof defaultSupplier === 'function') {
         return cache.get(key, defaultSupplier);
     } else {
         return cache.get(key);
     }
-}
+};
 
 /**
  * Associates the specified value with the specified key
@@ -43,9 +43,9 @@ let get = function (key, defaultSupplier) {
  * @param {*} value value to be associated with the specified key
  * @returns {(*|null)} the previous value associated with null, or null if there was no mapping for key
  */
-let put = function (key, value) {
+const put = function (key, value) {
     return cache.put(key, value);
-}
+};
 
 /**
  * Removes the mapping for a key from this map if it is present
@@ -54,12 +54,25 @@ let put = function (key, value) {
  * @param {string} key key whose mapping is to be removed from the map
  * @returns {(*|null)} the previous value associated with key or null if there was no mapping for key
  */
-let remove = function (key) {
+const remove = function (key) {
     return cache.remove(key);
-}
+};
+
+/**
+ * Checks the mapping for a key from this map.
+ * 
+ * @memberof cache
+ * @param {string} key key whose mapping is to be checked in the map
+ * @returns {boolean} whether the key has a mapping
+ */
+const exists = function (key) {
+    return get(key) !== null;
+};
+
 
 module.exports = {
     get,
     put,
-    remove
-}
+    remove,
+    exists
+};


### PR DESCRIPTION
Added a method to cache to check whether a key-value map exists.

Also changed from `let` to `const` as I don't see a reason it has to be `let`.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>