### PR TITLE
Re-Arrange .gitignore & Add .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-node_modules
-out
+.vscode
 dist
 docs
-.vscode
+node_modules
+openhab-*.tgz
+out

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# WARNING: Please keep in mind that npm disregards .gitignore when there is a .npmignore file!
+
+.github
+.vscode
+docs
+dist
+images
+openhab-*.tgz
+out
+test


### PR DESCRIPTION
Use .npmignore to reduce package size.

Testing the .npmignore (with `npm pack`) shows a decrease in size:

- package size: 489.8 kB -> 57.5 kB
- unpacked size: 836.0 kB -> 239.0 kB

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>