### PR TITLE
[time] Time Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,8 @@ openHAB internally makes extensive use of the `java.time` package.
 openHAB-JS exports the excellent [JS-Joda](#https://js-joda.github.io/js-joda/) library via the `time` namespace, which is a native JavaScript port of the same API standard used in Java for `java.time`.
 Anywhere that a native Java `ZonedDateTime` or `Duration` is required, the runtime will automatically convert a JS-Joda `ZonedDateTime` or `Duration` to its Java counterpart.
 
+The exported JS-Joda library is also extended with convenient functions relevant to openHAB usage.
+
 Examples:
 ```javascript
 var now = time.ZonedDateTime.now();
@@ -532,21 +534,21 @@ alarm.postUpdate(time.toZDT(alarm).toToday());
 #### `betweenTimes(start, end)`
 
 Tests whether this `time.ZonedDateTime` is between the passed in `start` and `end`.
-However, the function only compares the time portion of the the three, ignoring the date portion.
+However, the function only compares the time portion of the three, ignoring the date portion.
 The function takes into account times that span midnight.
 `start` and `end` can be anything supported by `time.toZDT()`.
 
 Examples:
 
 ```javascript
-time.toZDT().beteenTimes('22:00', '05:00') // currently between 11:00 pm and 5:00 am
+time.toZDT().betweenTimes('22:00', '05:00') // currently between 11:00 pm and 5:00 am
 time.toZDT().betweenTimes(items.getItem('Sunset'), '11:30 PM') // is now between sunset and 11:30 PM?
-time.toZDT(items.getItem('StartTime')).bewteenTimes(time.toZDT(), 'PT1H'); // is the state of StartTime between now and one hour from now
+time.toZDT(items.getItem('StartTime')).betweenTimes(time.toZDT(), 'PT1H'); // is the state of StartTime between now and one hour from now
 ```
 
 #### `isClose(zdt, maxDur)`
 
-Tests to see if the delta between `this` and the passed in `time.ZonedDateTime` is within the passed in `time.Duration`.
+Tests to see if the delta between the `time.ZonedDateTime` and the passed in `time.ZonedDateTime` is within the passed in `time.Duration`.
 
 ```javascript
 const timestamp = time.toZDT();

--- a/README.md
+++ b/README.md
@@ -497,11 +497,11 @@ See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete
 
 #### `time.toZDT()`
 
-There will be times where this automatic conversion is not available (for example when working with date times within a single rule).
-To ease having to deal with these cases a `toZDT()` function was added that will accept almost any type that can be converted to a `time.ZonedDateTime`.
+There will be times where this automatic conversion is not available (for example when working with date times within a rule).
+To ease having to deal with these cases a `time.toZDT()` function will accept almost any type that can be converted to a `time.ZonedDateTime`.
 The following rules are used during the conversion:
 
-Argument Type | Rule | Examples
+Argumen Type | Rule | Examples
 -|-|-
 `null` or `undefined` | `time.ZonedDateTime.now()` | `time.toZDT();`
 `time.ZonedDateTime` | passed through unmodified |
@@ -509,12 +509,12 @@ Argument Type | Rule | Examples
 JavaScript native `Date` | converted to the equivalent `time.ZonedDateTime` using `SYSTEM` as the timezone
 `number`, `bingint`, `java.lang.Number`, `DecimalType` | rounded to the nearest integer and added to `now` as milliseconds | `time.toZDT(1000);`
 `QuantityType` | if the units are `Time`, that time is added to `now` | `time.toZDT(item.getItem('MyTimeItem').rawState);`
-`items.Item` or `org.openhab.core.types.Item` | if the state is supported (see the `xType` rules in this table), the state is converted | `time.toZDT(items.getItem('MyItem'));
+`items.Item` or `org.openhab.core.types.Item` | if the state is supported (see the `Type` rules in this table, e.g. `DecimalType`), the state is converted | `time.toZDT(items.getItem('MyItem'));`
 `String`, `java.lang.String`, `StringType` | parsed based on the following rules |
-RFC String (output from a Java ZonedDateTime.toString()) | parsed | `time.toZDT(new DateTimeType().getZonedDateTime().toString());`
-"HH:MM[:ss]" (24 hour time) | today's date with the time indicated, seconds is optional | `time.toZDT('13:45:12');
-"kk:mm[:ss][ ]a" (12 hour time) | today's date with the time indicated, the space between the time and am/pm and seconds are optional | `time.toZDT('1:23:45 PM');
-Duration String | any duration string supported by `time.Duration0` added to `now()`, see [the docs](https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse) for details | `time.toZDT('PT1H4M6.789S');`
+RFC String (output from a Java `ZonedDateTime.toString()`) | parsed | `time.toZDT(new DateTimeType().getZonedDateTime().toString());`
+`"HH:MM[:ss]"` (24 hour time) | today's date with the time indicated, seconds is optional | `time.toZDT('13:45:12');`
+`"kk:mm[:ss][ ]a"` (12 hour time) | today's date with the time indicated, the space between the time and am/pm and seconds are optional | `time.toZDT('1:23:45 PM');`
+Duration String | any duration string supported by `time.Duration` added to `now()`, see [the docs](https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse) for details | `time.toZDT('PT1H4M6.789S');`
 
 When a type or string that cannot be handled is encountered, an error is thrown.
 
@@ -551,6 +551,7 @@ Tests to see if the delta between `this` and the passed in `time.ZonedDateTime` 
 const timestamp = time.toZDT();
 // do some stuff
 if(timestamp.isClose(time.toZDT(), time.Duration.ofMillis(100))) { // did "do some stuff" take longer than 100 msecs to run?
+```
 
 ### Utils
 

--- a/README.md
+++ b/README.md
@@ -501,20 +501,21 @@ There will be times where this automatic conversion is not available (for exampl
 To ease having to deal with these cases a `time.toZDT()` function will accept almost any type that can be converted to a `time.ZonedDateTime`.
 The following rules are used during the conversion:
 
-Argumen Type | Rule | Examples
--|-|-
-`null` or `undefined` | `time.ZonedDateTime.now()` | `time.toZDT();`
-`time.ZonedDateTime` | passed through unmodified |
-`java.time.ZonedDateTime` | converted to the `time.ZonedDateTime` equivalent
-JavaScript native `Date` | converted to the equivalent `time.ZonedDateTime` using `SYSTEM` as the timezone
-`number`, `bingint`, `java.lang.Number`, `DecimalType` | rounded to the nearest integer and added to `now` as milliseconds | `time.toZDT(1000);`
-`QuantityType` | if the units are `Time`, that time is added to `now` | `time.toZDT(item.getItem('MyTimeItem').rawState);`
-`items.Item` or `org.openhab.core.types.Item` | if the state is supported (see the `Type` rules in this table, e.g. `DecimalType`), the state is converted | `time.toZDT(items.getItem('MyItem'));`
-`String`, `java.lang.String`, `StringType` | parsed based on the following rules |
-RFC String (output from a Java `ZonedDateTime.toString()`) | parsed | `time.toZDT(new DateTimeType().getZonedDateTime().toString());`
-`"HH:MM[:ss]"` (24 hour time) | today's date with the time indicated, seconds is optional | `time.toZDT('13:45:12');`
-`"kk:mm[:ss][ ]a"` (12 hour time) | today's date with the time indicated, the space between the time and am/pm and seconds are optional | `time.toZDT('1:23:45 PM');`
-Duration String | any duration string supported by `time.Duration` added to `now()`, see [the docs](https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse) for details | `time.toZDT('PT1H4M6.789S');`
+| Argument Type                                              | Rule                                                                                                                                                                                                   | Examples                                                        |
+|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `null` or `undefined`                                      | `time.ZonedDateTime.now()`                                                                                                                                                                             | `time.toZDT();`                                                 |
+| `time.ZonedDateTime`                                       | passed through unmodified                                                                                                                                                                              |                                                                 |
+| `java.time.ZonedDateTime`                                  | converted to the `time.ZonedDateTime` equivalent                                                                                                                                                       |                                                                 |
+| JavaScript native `Date`                                   | converted to the equivalent `time.ZonedDateTime` using `SYSTEM` as the timezone                                                                                                                        |                                                                 |
+| `number`, `bingint`, `java.lang.Number`, `DecimalType`     | rounded to the nearest integer and added to `now` as milliseconds                                                                                                                                      | `time.toZDT(1000);`                                             |
+| `QuantityType`                                             | if the units are `Time`, that time is added to `now`                                                                                                                                                   | `time.toZDT(item.getItem('MyTimeItem').rawState);`              |
+| `items.Item` or `org.openhab.core.types.Item`              | if the state is supported (see the `Type` rules in this table, e.g. `DecimalType`), the state is converted                                                                                             | `time.toZDT(items.getItem('MyItem'));`                          |
+| `String`, `java.lang.String`, `StringType`                 | parsed based on the following rules                                                                                                                                                                    |                                                                 |
+| RFC String (output from a Java `ZonedDateTime.toString()`) | parsed                                                                                                                                                                                                 | `time.toZDT(new DateTimeType().getZonedDateTime().toString());` |
+| `"HH:MM[:ss]"` (24 hour time)                              | today's date with the time indicated, seconds is optional                                                                                                                                              | `time.toZDT('13:45:12');`                                       |
+| `"kk:mm[:ss][ ]a"` (12 hour time)                          | today's date with the time indicated, the space between the time and am/pm and seconds are optional                                                                                                    | `time.toZDT('1:23:45 PM');`                                     |
+| Duration String                                            | any duration string supported by `time.Duration` added to `now()`, see [the docs](https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse) for details | `time.toZDT('PT1H4M6.789S');`                                   |
+
 
 When a type or string that cannot be handled is encountered, an error is thrown.
 

--- a/time.js
+++ b/time.js
@@ -18,7 +18,6 @@ const ohItem = Java.type('org.openhab.core.items.Item');
 /**
  * Converts the Java ZonedDateTime to a time.ZonedDateTime
  * @private
- * @memberof time
  * @param {java.time.ZonedDateTime} zdt date time to convert to a time.ZonedDateTime
  * @returns {time.ZonedDateTime}
  */
@@ -33,7 +32,6 @@ const javaZDTtoZDT = function(zdt) {
  * Adds millis to the passed in ZDT as milliseconds. The millis is rounded 
  * first. If millis is negative they will be subtracted.
  * @private
- * @memberof time
  * @param {number|bigint} millis number of milliseconds to add
  */
 const addMillisToNow = function(millis) {
@@ -43,7 +41,6 @@ const addMillisToNow = function(millis) {
 /**
  * Adds the passed in QuantityType<Time> to now.
  * @private
- * @memberof time
  * @param {QuantityType} quantityType an Item's QuantityType
  * @returns now plus the time length in the quantityType
  * @throws error when the units for the quantity type are not one of the Time units
@@ -60,7 +57,6 @@ const addQuantityType = function(quantityType) {
 /**
  * Tests the passed in string to see if it conforms to the ISO8601 standard
  * @private
- * @memberof time
  * @param {String} dtStr potential ISO8601 string
  * @returns {boolean} true if ISO8601 format
  */
@@ -72,7 +68,6 @@ const isISO8601 = (dtStr) => {
 /**
  * Tests the string to see if it matches a 24 hour clock time
  * @private
- * @memberof time
  * @param {String} dtStr potential HH:MM String
  * @returns {boolean} true if it matches HH:MM
  */
@@ -84,7 +79,6 @@ const isISO8601 = (dtStr) => {
 /**
  * Tests the string to see if it matches a 12 hour clock time
  * @private
- * @memberof time
  * @param {String} dtStr potential hh:MM aa string
  * @returns {boolean} true if it matches hh:mm aa 
  */
@@ -96,7 +90,6 @@ const is12Hr = function (dtStr) {
 /**
  * Parses the passed in string based on it's format and converted to a ZonedDateTime.
  * @private
- * @memberof time
  * @param {String} str string number to try and parse and convert
  * @throws Error when the string cannot be parsed
  */
@@ -154,7 +147,6 @@ const parseString = function(str) {
 /**
  * Converts the state of the passed in Item to a time.ZonedDateTime
  * @private
- * @memberof time
  * @param {items.Item} item 
  * @returns {time.ZonedDateTime}
  * @throws error if the Item's state is not supported or the Item itself is not supported

--- a/time.js
+++ b/time.js
@@ -5,326 +5,324 @@
  * @namespace time
  */
 
- require('@js-joda/timezone');
- const time = require('@js-joda/core');
+require('@js-joda/timezone');
+const time = require('@js-joda/core');
+
+const javaZDT = Java.type('java.time.ZonedDateTime');
+const javaDuration = Java.type('java.time.Duration');
+const javaString = Java.type('java.lang.String');
+const javaNumber = Java.type('java.lang.Number');
+const { DateTimeType, DecimalType, StringType, QuantityType } = require('@runtime');
+const ohItem = Java.type('org.openhab.core.items.Item');
+
+/**
+ * Converts the Java ZonedDateTime to a time.ZonedDateTime
+ * @param {java.time.ZonedDateTime} zdt date time to convert to a time.ZonedDateTime
+ * @returns {time.ZonedDateTime}
+ */
+const javaZDTtoZDT = function(zdt) {
+    const epoch = zdt.toInstant().toEpochMilli();
+    const instant = time.Instant.ofEpochMilli(epoch);
+    const zone = time.ZoneId.of(zdt.getZone().toString());
+    return time.ZonedDateTime.ofInstant(instant, zone);
+}
+
+/**
+ * Adds millis to the passed in ZDT as milliseconds. The millis is rounded 
+ * first. If millis is negative they will be subtracted.
+ * @param {number|bigint} millis number of milliseconds to add
+ */
+const addMillisToNow = function(millis) {
+    return time.ZonedDateTime.now().plus(Math.round(millis), time.ChronoUnit.MILLIS);
+}
+
+/**
+ * Adds the passed in QuantityType<Time> to now.
+ * @param {QuantityType} quantityType an Item's QuantityType
+ * @returns now plus the time length in the quantityType
+ * @throws error when the units for the quantity type are not one of the Time units
+ */
+const addQuantityType = function(quantityType) {
+    const secs = quantityType.toUnit('s');
+    if(secs) {
+        return time.ZonedDateTime.now().plusSeconds(secs.doubleValue());
+    } else {
+        throw Error('Only Time units are supported to convert QuantityTypes to a ZonedDateTime: ' + quantityType.toString());
+    }
+}
+
+/**
+ * Tests the passed in string to see if it conforms to the ISO8601 standard
+ * @param {String} dtStr potential ISO8601 string
+ * @returns {boolean} true if ISO8601 format
+ */
+const isISO8601 = (dtStr) => {
+  var regex = new RegExp(/^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/);
+  return regex.test(dtStr);    
+}
+
+/**
+ * Tests the string to see if it matches a 24 hour clock time
+ * @param {String} dtStr potential HH:MM String
+ * @returns {boolean} true if it matches HH:MM
+ */
+ const is24Hr = function (dtStr) {
+    var regex = new RegExp(/^(0?[0-9]|1[0-9]|2[0-3])(:[0-5][0-9]){1,2}$/);
+    return regex.test(dtStr);
+}
+
+/**
+ * Tests the string to see if it matches a 12 hour clock time
+ * @param {String} dtStr potential hh:MM aa string
+ * @returns {boolean} true if it matches hh:mm aa 
+ */
+const is12Hr = function (dtStr) {
+    var regex = new RegExp(/^(0?[0-9]|1[0-2])(:[0-5][0-9]){1,2} ?[a|p|A|P]\.?[m|M]\.?$/);
+    return regex.test(dtStr);
+}
+
+/**
+ * Parses the passed in string based on it's format and converted to a ZonedDateTime.
+ * @param {String} str string number to try and parse and convert
+ * @throws Error when the string cannot be parsed
+ */
+const parseString = function(str) {
+
+    // Number
+    if(!isNaN(str)) {
+        return addMillisToNow(str);
+    }
+
+    // ISO8601
+    else if(isISO8601(str)) {
+        throw Error('ISO 8601 strings are not yet supported');
+    }
+
+    // 24 hour time string
+    else if(is24Hr(str)) {
+        const parts = str.split(':');
+        return time.ZonedDateTime.now().withHour(parts[0])
+                                       .withMinute(parts[1])
+                                       .withSecond(parts[2] || 0)
+                                       .withNano(0);
+    }
+
+    // 12 hour time string
+    else if(is12Hr(str)) {
+        const parts = str.split(':');
+        let hr = parseInt(parts[0]);
+        hr = (str.contains('p') || str.contains('P')) ? hr + 12 : hr;
+        return time.ZonedDateTime.now().withHour(hr) 
+                                       .withMinute(parseInt(parts[1])) // parseInt will ignore the am/pm
+                                       .withSecond(parseInt(parts[2]) || 0)
+                                       .withNano(0);
+    }
+
+    else {
+
+        // Java ZonedDateTime's toString format (see monkey patched parse function)
+        try {
+            return time.ZonedDateTime.parse(str);
+        }
+
+        // Duration string
+        catch(e) {
+            try {
+                return time.ZonedDateTime.now().plus(time.Duration.parse(str));
+            }
+
+            // Unsupported
+            catch(e) {
+                throw Error('"' + str + '" cannot be parsed into a format that can be converted to a ZonedDateTime');
+            }
+        }
+    }
+
+}
+
+/**
+ * Converts the state of the passed in Item to a time.ZonedDateTime
+ * @param {items.Item} item 
+ * @returns {time.ZonedDateTime}
+ * @throws error if the Item's state is not supported or the Item itself is not supported
+ */
+const convertItem = function(item) {
+
+
+    // Uninitialized
+    if(item.isUninitialized) {
+        throw Error('Item ' + item.name + ' is NULL or UNDEF, cannot convert to a time.ZonedDateTime');
+    }
+
+    // Number type Items
+    else if(item.rawState instanceof DecimalType) {
+        return addMillisToNow(item.rawState.floatValue());
+    }
+
+    // String type Items
+    else if(item.rawState instanceof StringType) {
+        return parseString(item.state);
+    }
+
+    // DateTime Items
+    else if(item.rawState instanceof DateTimeType) {
+        return javaZDTtoZDT(item.rawState.getZonedDateTime());
+    }
+
+    // Number:Time type Items
+    else if(item.rawState instanceof QuantityType) {
+        return addQuantityType(item.rawState);
+    }
+
+    else {
+        throw Error(item.type + ' is not supported for conversion to time.ZonedDateTime');
+    }
+}
+
+/**
+ * Converts the passed in when to a time.ZonedDateTime based on the following 
+ * set of rules.
+ * 
+ * - null, undefined: time.ZonedDateTime.now()
+ * - time.ZonedDateTime: unmodified
+ * - Java ZonedDateTime, DateTimeType: converted to time.ZonedDateTime equivalnet
+ * - JavaScript native Date: converted to a time.ZonedDateTime using SYSTEM as the timezone
+ * - number, bigint, Java Number, DecimalType: rounded and added to time.ZonedDateTime.now() as milliseconds
+ * - QuantityType: if the units are Time, added to now
+ * - Item: converts the state of the Item based on the *Type rules described here
+ * - String, Java String, StringType: Parsed based on the following rules
+ *     - ISO 8601: Not yet implemented
+ *     - RFC (output from a Java ZonedDateTime.toString()): parsed to time.ZonedDateTime
+ *     - HH:mm[:ss] (i.e. 24 hour time): that time with today's date (seconds are optional)
+ *     - KK:mm[:ss][ ][aa] (i.e. 12 hour time): that time with today's date (seconds and space between time and am/pm are optional)
+ *     - Duration: any duration string supported by time.Duration (e.g. 'PT5H4M3.210S'), see https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse
+ * @param {*} when any of the types discussed above
+ * @returns time.ZonedDateTime
+ * @throws error if the type, format, or contents of when are not supported
+ */
+time.toZDT = function(when) {
+
+    // If when is not supplied or null, return now
+    if(when === undefined || when === null) {
+        return time.ZonedDateTime.now();
+    }
+
+    // Pass through if already a time.ZonedDateTime
+    else if(when instanceof time.ZonedDateTime) {
+        return when;
+    }
+
+    // Java ZDT
+    else if(when instanceof javaZDT) {
+        return javaZDTtoZDT(when);
+    }
+
+    // DateTimeType, extract the javaZDT and convert to time.ZDT
+    else if(when instanceof DateTimeType) {
+        return javaZDTtoZDT(when.getZonedDateTime());
+    }
+
+    // JavaScript Native Date, use the SYSTEM timezone
+    else if(when instanceof Date) {
+        const native = time.nativeJs(when);
+        const instant = time.Instant.from(native);
+        return time.ZonedDateTime.ofInstant(instant, time.ZoneId.SYSTEM);
+    }
+
+    // Duration, add to now
+    else if(when instanceof time.Duration || when instanceof javaDuration) {
+        return time.ZonedDateTime.now().plus(time.Duration.parse(when.toString()));
+    }
+
+    // JavaScript number of bigint, add as millisecs to now
+    else if(typeof when === 'number' || typeof when === 'bigint') {
+        return addMillisToNow(when);
+    }
+
+    // QuantityType<Time>, add to now
+    else if(when instanceof QuantityType) {
+        return addQuantityType(when);
+    }
+
+    // Java Number of DecimalType, add as millisecs to now
+    else if(when instanceof javaNumber || when instanceof DecimalType) {
+        return addMillisToNow(when.floatValue());
+    }
+
+    // String or StringType
+    else if(typeof when === 'string' || when instanceof javaString || when instanceof StringType) {
+        return parseString(when.toString());
+    }
+
+    // GenericItem
+    else if(when instanceof ohItem) {
+        return convertItem(items.getItem(when.name));
+    }
+
+    // items.Item
+    else if(when.constructor.name === 'Item') {
+        return convertItem(when);
+    }
+
+    // Unsupported
+    throw Error('"' + when + '" is an unsupported type for conversion to time.ZonedDateTime');
+
+}
+
+//openHAB uses a RFC DateTime string, js-joda defaults to the ISO version, this defaults RFC instead
+const rfcFormatter = time.DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS[xxxx][xxxxx]");
+const targetParse = time.ZonedDateTime.prototype.parse;
+time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
+    return targetParse(text, formatter);
+}
+
+/**
+ * Moves the date portion of the date time to today, accounting for DST
+ */
+ time.ZonedDateTime.prototype.toToday = function () {
+    let now = time.ZonedDateTime.now();
+    return this.withYear(now.year())
+               .withMonth(now.month())
+               .withDayOfMonth(now.dayOfMonth());
+}
+
+/**
+ * Compares this ZDT to see if it falls between start and end times,
+ * accounting for times that span midnight. start and end can be any type
+ * that has a `toZonedDateTime()` method.
+ * time.toZDT is called on the arguments. Examples:
+ * 
+ * time.ZonedDateTime.now().betweenTimes(items.getItem('Sunset'), "23:30:00") // is now between sunset and 11:00 pm?
+ * time.toZDT(items.geItem('MyDateTimeItem')).betweenTimes(time.toZDT(), time.toZDT(1000)) // is the state of MyDateTimeItem between now and a second from now?
+ * 
+ * @param {*} start the starting time in anything that can be 
+ * @param {*} end the ending time
+ * @returns {Boolean} true if this is between start and end
+ */
+ time.ZonedDateTime.prototype.betweenTimes = function(start, end) {
+    startTime = time.toZDT(start).toLocalTime();
+    endTime = time.toZDT(end).toLocalTime();
+    currTime = this.toLocalTime();
+
+    // time range spans midnight
+    if(endTime.isBefore(startTime)) {
+        return currTime.isAfter(startTime) || currTime.isBefore(endTime);
+    }
+    else {
+        return currTime.isAfter(startTime) && currTime.isBefore(endTime);
+    }
+} 
  
- const javaZDT = Java.type('java.time.ZonedDateTime');
- const javaDuration = Java.type('java.time.Duration');
- const javaString = Java.type('java.lang.String');
- const javaNumber = Java.type('java.lang.Number');
- const { DateTimeType, DecimalType, StringType, QuantityType } = require('@runtime');
- const ohItem = Java.type('org.openhab.core.items.Item');
+/**
+ * Tests to see if the difference betwee this and the passed in ZoneDateTime is
+ * within the passed in maxDur.
+ * @param {time.ZonedDateTime} zdt the date tiem to compare to this
+ * @param {time.Duration} maxDur the duration to test that the difference between this and zdt is within
+ * @returns {Boolean} true if the delta between this and zdt is within maxDur
+ */
+time.ZonedDateTime.prototype.isClose = function(zdt, maxDur) {
+    const delta = time.Duration.between(this, zdt).abs();
+    return delta.compareTo(maxDur) <= 0;
+}
  
- /**
-  * Converts the Java ZonedDateTime to a time.ZonedDateTime
-  * @param {java.time.ZonedDateTime} zdt date time to convert to a time.ZonedDateTime
-  * @returns {time.ZonedDateTime}
-  */
- const javaZDTtoZDT = function(zdt) {
-     const epoch = zdt.toInstant().toEpochMilli();
-     const instant = time.Instant.ofEpochMilli(epoch);
-     const zone = time.ZoneId.of(zdt.getZone().toString());
-     return time.ZonedDateTime.ofInstant(instant, zone);
- }
- 
- /**
-  * Adds millis to the passed in ZDT as milliseconds. The millis is rounded 
-  * first. If millis is negative they will be subtracted.
-  * @param {number|bigint} millis number of milliseconds to add
-  */
- const addMillisToNow = function(millis) {
-     return time.ZonedDateTime.now().plus(Math.round(millis), time.ChronoUnit.MILLIS);
- }
- 
- /**
-  * Adds the passed in QuantityType<Time> to now.
-  * @param {QuantityType} quantityType an Item's QuantityType
-  * @returns now plus the time length in the quantityType
-  * @throws error when the units for the quantity type are not one of the Time units
-  */
- const addQuantityType = function(quantityType) {
-     const secs = quantityType.toUnit('s');
-     if(secs) {
-         return time.ZonedDateTime.now().plusSeconds(secs.doubleValue());
-     } else {
-         throw Error('Only Time units are supported to convert QuantityTypes to a ZonedDateTime: ' + quantityType.toString());
-     }
- }
- 
- /**
-  * Tests the passed in string to see if it conforms to the ISO8601 standard
-  * @param {String} dtStr potential ISO8601 string
-  * @returns {boolean} true if ISO8601 format
-  */
- const isISO8601 = (dtStr) => {
-   var regex = new RegExp(/^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/);
-   return regex.test(dtStr);    
- }
- 
- /**
-  * Tests the string to see if it matches a 24 hour clock time
-  * @param {String} dtStr potential HH:MM String
-  * @returns {boolean} true if it matches HH:MM
-  */
-  const is24Hr = function (dtStr) {
-     var regex = new RegExp(/^(0?[0-9]|1[0-9]|2[0-3])(:[0-5][0-9]){1,2}$/);
-     return regex.test(dtStr);
- }
- 
- /**
-  * Tests the string to see if it matches a 12 hour clock time
-  * @param {String} dtStr potential hh:MM aa string
-  * @returns {boolean} true if it matches hh:mm aa 
-  */
- const is12Hr = function (dtStr) {
-     var regex = new RegExp(/^(0?[0-9]|1[0-2])(:[0-5][0-9]){1,2} ?[a|p|A|P]\.?[m|M]\.?$/);
-     return regex.test(dtStr);
- }
- 
- /**
-  * Parses the passed in string based on it's format and converted to a ZonedDateTime.
-  * @param {String} str string number to try and parse and convert
-  * @throws Error when the string cannot be parsed
-  */
- const parseString = function(str) {
- 
-     // Number
-     if(!isNaN(str)) {
-         return addMillisToNow(str);
-     }
- 
-     // ISO8601
-     else if(isISO8601(str)) {
-         throw Error('ISO 8601 strings are not yet supported');
-     }
- 
-     // 24 hour time string
-     else if(is24Hr(str)) {
-         const parts = str.split(':');
-         return time.ZonedDateTime.now().withHour(parts[0])
-                                        .withMinute(parts[1])
-                                        .withSecond(parts[2] || 0)
-                                        .withNano(0);
-     }
- 
-     // 12 hour time string
-     else if(is12Hr(str)) {
-         const parts = str.split(':');
-         let hr = parseInt(parts[0]);
-         hr = (str.contains('p') || str.contains('P')) ? hr + 12 : hr;
-         return time.ZonedDateTime.now().withHour(hr) 
-                                        .withMinute(parseInt(parts[1])) // parseInt will ignore the am/pm
-                                        .withSecond(parseInt(parts[2]) || 0)
-                                        .withNano(0);
-     }
- 
-     else {
- 
-         // Java ZonedDateTime's toString format (see monkey patched parse function)
-         try {
-             return time.ZonedDateTime.parse(str);
-         }
- 
-         // Duration string
-         catch(e) {
-             try {
-                 return time.ZonedDateTime.now().plus(time.Duration.parse(str));
-             }
- 
-             // Unsupported
-             catch(e) {
-                 throw Error('"' + str + '" cannot be parsed into a format that can be converted to a ZonedDateTime');
-             }
-         }
-     }
- 
- }
- 
- /**
-  * Converts the state of the passed in Item to a time.ZonedDateTime
-  * @param {items.Item} item 
-  * @returns {time.ZonedDateTime}
-  * @throws error if the Item's state is not supported or the Item itself is not supported
-  */
- const convertItem = function(item) {
- 
- 
-     // Uninitialized
-     if(item.isUninitialized) {
-         throw Error('Item ' + item.name + ' is NULL or UNDEF, cannot convert to a time.ZonedDateTime');
-     }
- 
-     // Number type Items
-     else if(item.rawState instanceof DecimalType) {
-         return addMillisToNow(item.rawState.floatValue());
-     }
- 
-     // String type Items
-     else if(item.rawState instanceof StringType) {
-         return parseString(item.state);
-     }
- 
-     // DateTime Items
-     else if(item.rawState instanceof DateTimeType) {
-         return javaZDTtoZDT(item.rawState.getZonedDateTime());
-     }
- 
-     // Number:Time type Items
-     else if(item.rawState instanceof QuantityType) {
-         return addQuantityType(item.rawState);
-     }
- 
-     else {
-         throw Error(item.type + ' is not supported for conversion to time.ZonedDateTime');
-     }
- }
- 
- /**
-  * Converts the passed in when to a time.ZonedDateTime based on the following 
-  * set of rules.
-  * 
-  * - null, undefined: time.ZonedDateTime.now()
-  * - time.ZonedDateTime: unmodified
-  * - Java ZonedDateTime, DateTimeType: converted to time.ZonedDateTime equivalnet
-  * - JavaScript native Date: converted to a time.ZonedDateTime using SYSTEM as the timezone
-  * - number, bigint, Java Number, DecimalType: rounded and added to time.ZonedDateTime.now() as milliseconds
-  * - QuantityType: if the units are Time, added to now
-  * - Item: converts the state of the Item based on the *Type rules described here
-  * - String, Java String, StringType: Parsed based on the following rules
-  *     - ISO 8601: Not yet implemented
-  *     - RFC (output from a Java ZonedDateTime.toString()): parsed to time.ZonedDateTime
-  *     - HH:mm[:ss] (i.e. 24 hour time): that time with today's date (seconds are optional)
-  *     - KK:mm[:ss][ ][aa] (i.e. 12 hour time): that time with today's date (seconds and space between time and am/pm are optional)
-  *     - Duration: any duration string supported by time.Duration (e.g. 'PT5H4M3.210S'), see https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse
-  * @param {*} when any of the types discussed above
-  * @returns time.ZonedDateTime
-  * @throws error if the type, format, or contents of when are not supported
-  */
- time.toZDT = function(when) {
- 
-     // If when is not supplied or null, return now
-     if(when === undefined || when === null) {
-         return time.ZonedDateTime.now();
-     }
- 
-     // Pass through if already a time.ZonedDateTime
-     else if(when instanceof time.ZonedDateTime) {
-         return when;
-     }
- 
-     // Java ZDT
-     else if(when instanceof javaZDT) {
-         return javaZDTtoZDT(when);
-     }
- 
-     // DateTimeType, extract the javaZDT and convert to time.ZDT
-     else if(when instanceof DateTimeType) {
-         return javaZDTtoZDT(when.getZonedDateTime());
-     }
- 
-     // JavaScript Native Date, use the SYSTEM timezone
-     else if(when instanceof Date) {
-         const native = time.nativeJs(when);
-         const instant = time.Instant.from(native);
-         return time.ZonedDateTime.ofInstant(instant, time.ZoneId.SYSTEM);
-     }
- 
-     // Duration, add to now
-     else if(when instanceof time.Duration || when instanceof javaDuration) {
-         return time.ZonedDateTime.now().plus(time.Duration.parse(when.toString()));
-     }
- 
-     // JavaScript number of bigint, add as millisecs to now
-     else if(typeof when === 'number' || typeof when === 'bigint') {
-         return addMillisToNow(when);
-     }
- 
-     // QuantityType<Time>, add to now
-     else if(when instanceof QuantityType) {
-         return addQuantityType(when);
-     }
- 
-     // Java Number of DecimalType, add as millisecs to now
-     else if(when instanceof javaNumber || when instanceof DecimalType) {
-         return addMillisToNow(when.floatValue());
-     }
- 
-     // String or StringType
-     else if(typeof when === 'string' || when instanceof javaString || when instanceof StringType) {
-         return parseString(when.toString());
-     }
- 
-     // GenericItem
-     else if(when instanceof ohItem) {
-         return convertItem(items.getItem(when.name));
-     }
- 
-     // items.Item
-     else if(when.constructor.name === 'Item') {
-         return convertItem(when);
-     }
- 
-     // Unsupported
-     throw Error('"' + when + '" is an unsupported type for conversion to time.ZonedDateTime');
- 
- }
- 
- //openHAB uses a RFC DateTime string, js-joda defaults to the ISO version, this defaults RFC instead
- const rfcFormatter = time.DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS[xxxx][xxxxx]");
- const targetParse = time.ZonedDateTime.prototype.parse;
- time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
-     return targetParse(text, formatter);
- }
- 
- /**
-  * Moves the date portion of the date time to today, accounting for DST
-  */
-  time.ZonedDateTime.prototype.toToday = function () {
-     let now = time.ZonedDateTime.now();
-     return this.withYear(now.year())
-                .withMonth(now.month())
-                .withDayOfMonth(now.dayOfMonth());
- }
- 
- /**
-  * Compares this ZDT to see if it falls between start and end times,
-  * accounting for times that span midnight. start and end can be any type
-  * that has a `toZonedDateTime()` method.
-  * time.toZDT is called on the arguments. Examples:
-  * 
-  * time.ZonedDateTime.now().betweenTimes(items.getItem('Sunset'), "23:30:00") // is now between sunset and 11:00 pm?
-  * time.toZDT(items.geItem('MyDateTimeItem')).betweenTimes(time.toZDT(), time.toZDT(1000)) // is the state of MyDateTimeItem between now and a second from now?
-  * 
-  * @param {*} start the starting time in anything that can be 
-  * @param {*} end the ending time
-  * @returns {Boolean} true if this is between start and end
-  */
-  time.ZonedDateTime.prototype.betweenTimes = function(start, end) {
-     start = time.toZDT(start).toLocalTime();
-     end = time.toZDT(end).toLocalTime();
-     time = this.toLocalTime();
- 
-     // time range spans midnight
-     if(end.isBefore(start)) {
-         return (time.isAfter(start) && time.isBefore(time.LocalTime.MIDNIGHT)) 
-                || (time.isAfter(time.LocalTime.MIDNIGHT) && time.isBefore(end));
-     }
-     else {
-         return time.isAfter(start) && time.isBefore(end);
-     }
-     
- }
- 
- /**
-  * Tests to see if the difference betwee this and the passed in ZoneDateTime is
-  * within the passed in maxDur.
-  * @param {time.ZonedDateTime} zdt the date tiem to compare to this
-  * @param {time.Duration} maxDur the duration to test that the difference between this and zdt is within
-  * @returns {Boolean} true if the delta between this and zdt is within maxDur
-  */
- time.ZonedDateTime.prototype.isClose = function(zdt, maxDur) {
-     const delta = time.Duration.between(this, zdt).abs();
-     return delta.compareTo(maxDur) <= 0;
- }
- 
- module.exports = time;
+module.exports = time;

--- a/time.js
+++ b/time.js
@@ -17,6 +17,8 @@ const ohItem = Java.type('org.openhab.core.items.Item');
 
 /**
  * Converts the Java ZonedDateTime to a time.ZonedDateTime
+ * @private
+ * @memberof time
  * @param {java.time.ZonedDateTime} zdt date time to convert to a time.ZonedDateTime
  * @returns {time.ZonedDateTime}
  */
@@ -30,6 +32,8 @@ const javaZDTtoZDT = function(zdt) {
 /**
  * Adds millis to the passed in ZDT as milliseconds. The millis is rounded 
  * first. If millis is negative they will be subtracted.
+ * @private
+ * @memberof time
  * @param {number|bigint} millis number of milliseconds to add
  */
 const addMillisToNow = function(millis) {
@@ -38,6 +42,8 @@ const addMillisToNow = function(millis) {
 
 /**
  * Adds the passed in QuantityType<Time> to now.
+ * @private
+ * @memberof time
  * @param {QuantityType} quantityType an Item's QuantityType
  * @returns now plus the time length in the quantityType
  * @throws error when the units for the quantity type are not one of the Time units
@@ -53,6 +59,8 @@ const addQuantityType = function(quantityType) {
 
 /**
  * Tests the passed in string to see if it conforms to the ISO8601 standard
+ * @private
+ * @memberof time
  * @param {String} dtStr potential ISO8601 string
  * @returns {boolean} true if ISO8601 format
  */
@@ -63,6 +71,8 @@ const isISO8601 = (dtStr) => {
 
 /**
  * Tests the string to see if it matches a 24 hour clock time
+ * @private
+ * @memberof time
  * @param {String} dtStr potential HH:MM String
  * @returns {boolean} true if it matches HH:MM
  */
@@ -73,6 +83,8 @@ const isISO8601 = (dtStr) => {
 
 /**
  * Tests the string to see if it matches a 12 hour clock time
+ * @private
+ * @memberof time
  * @param {String} dtStr potential hh:MM aa string
  * @returns {boolean} true if it matches hh:mm aa 
  */
@@ -83,6 +95,8 @@ const is12Hr = function (dtStr) {
 
 /**
  * Parses the passed in string based on it's format and converted to a ZonedDateTime.
+ * @private
+ * @memberof time
  * @param {String} str string number to try and parse and convert
  * @throws Error when the string cannot be parsed
  */
@@ -139,6 +153,8 @@ const parseString = function(str) {
 
 /**
  * Converts the state of the passed in Item to a time.ZonedDateTime
+ * @private
+ * @memberof time
  * @param {items.Item} item 
  * @returns {time.ZonedDateTime}
  * @throws error if the Item's state is not supported or the Item itself is not supported
@@ -193,6 +209,7 @@ const convertItem = function(item) {
  *     - HH:mm[:ss] (i.e. 24 hour time): that time with today's date (seconds are optional)
  *     - KK:mm[:ss][ ][aa] (i.e. 12 hour time): that time with today's date (seconds and space between time and am/pm are optional)
  *     - Duration: any duration string supported by time.Duration (e.g. 'PT5H4M3.210S'), see https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse
+ * @memberof time
  * @param {*} when any of the types discussed above
  * @returns time.ZonedDateTime
  * @throws error if the type, format, or contents of when are not supported
@@ -275,6 +292,8 @@ time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
 
 /**
  * Moves the date portion of the date time to today, accounting for DST
+ * @memberof time
+ * @returns {time.ZonedDateTime} a new date time with today's date
  */
  time.ZonedDateTime.prototype.toToday = function () {
     let now = time.ZonedDateTime.now();
@@ -291,15 +310,15 @@ time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
  * 
  * time.ZonedDateTime.now().betweenTimes(items.getItem('Sunset'), "23:30:00") // is now between sunset and 11:00 pm?
  * time.toZDT(items.geItem('MyDateTimeItem')).betweenTimes(time.toZDT(), time.toZDT(1000)) // is the state of MyDateTimeItem between now and a second from now?
- * 
+ * @memberof time
  * @param {*} start the starting time in anything that can be 
  * @param {*} end the ending time
  * @returns {Boolean} true if this is between start and end
  */
  time.ZonedDateTime.prototype.isBetweenTimes = function(start, end) {
-    startTime = time.toZDT(start).toLocalTime();
-    endTime = time.toZDT(end).toLocalTime();
-    currTime = this.toLocalTime();
+    const startTime = time.toZDT(start).toLocalTime();
+    const endTime = time.toZDT(end).toLocalTime();
+    const currTime = this.toLocalTime();
 
     // time range spans midnight
     if(endTime.isBefore(startTime)) {
@@ -313,6 +332,7 @@ time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
 /**
  * Tests to see if the difference between this and the passed in ZoneDateTime is
  * within the passed in maxDur.
+ * @memberof time
  * @param {time.ZonedDateTime} zdt the date time to compare to this
  * @param {time.Duration} maxDur the duration to test that the difference between this and zdt is within
  * @returns {Boolean} true if the delta between this and zdt is within maxDur

--- a/time.js
+++ b/time.js
@@ -5,24 +5,326 @@
  * @namespace time
  */
 
-require('@js-joda/timezone');
-const time = require('@js-joda/core');
-
-// openHAB uses a RFC DateTime string, js-joda defaults to the ISO version, this defaults RFC instead
-const rfcFormatter = time.DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS[xxxx][xxxxx]");
-const targetParse = time.ZonedDateTime.prototype.parse;
-time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
-  return targetParse(text, formatter);
-};
-
-/**
- * Parses a ZonedDateTime to milliseconds from now until the ZonedDateTime.
- *
- * @memberof time
- * @returns {number} duration from now to the ZonedDateTime in milliseconds
- */
-time.ZonedDateTime.prototype.millisFromNow = function () {
-  return time.Duration.between(time.ZonedDateTime.now(), this).toMillis();
-};
-
-module.exports = time;
+ require('@js-joda/timezone');
+ const time = require('@js-joda/core');
+ 
+ const javaZDT = Java.type('java.time.ZonedDateTime');
+ const javaDuration = Java.type('java.time.Duration');
+ const javaString = Java.type('java.lang.String');
+ const javaNumber = Java.type('java.lang.Number');
+ const { DateTimeType, DecimalType, StringType, QuantityType } = require('@runtime');
+ const ohItem = Java.type('org.openhab.core.items.Item');
+ 
+ /**
+  * Converts the Java ZonedDateTime to a time.ZonedDateTime
+  * @param {java.time.ZonedDateTime} zdt date time to convert to a time.ZonedDateTime
+  * @returns {time.ZonedDateTime}
+  */
+ const javaZDTtoZDT = function(zdt) {
+     const epoch = zdt.toInstant().toEpochMilli();
+     const instant = time.Instant.ofEpochMilli(epoch);
+     const zone = time.ZoneId.of(zdt.getZone().toString());
+     return time.ZonedDateTime.ofInstant(instant, zone);
+ }
+ 
+ /**
+  * Adds millis to the passed in ZDT as milliseconds. The millis is rounded 
+  * first. If millis is negative they will be subtracted.
+  * @param {number|bigint} millis number of milliseconds to add
+  */
+ const addMillisToNow = function(millis) {
+     return time.ZonedDateTime.now().plus(Math.round(millis), time.ChronoUnit.MILLIS);
+ }
+ 
+ /**
+  * Adds the passed in QuantityType<Time> to now.
+  * @param {QuantityType} quantityType an Item's QuantityType
+  * @returns now plus the time length in the quantityType
+  * @throws error when the units for the quantity type are not one of the Time units
+  */
+ const addQuantityType = function(quantityType) {
+     const secs = quantityType.toUnit('s');
+     if(secs) {
+         return time.ZonedDateTime.now().plusSeconds(secs.doubleValue());
+     } else {
+         throw Error('Only Time units are supported to convert QuantityTypes to a ZonedDateTime: ' + quantityType.toString());
+     }
+ }
+ 
+ /**
+  * Tests the passed in string to see if it conforms to the ISO8601 standard
+  * @param {String} dtStr potential ISO8601 string
+  * @returns {boolean} true if ISO8601 format
+  */
+ const isISO8601 = (dtStr) => {
+   var regex = new RegExp(/^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/);
+   return regex.test(dtStr);    
+ }
+ 
+ /**
+  * Tests the string to see if it matches a 24 hour clock time
+  * @param {String} dtStr potential HH:MM String
+  * @returns {boolean} true if it matches HH:MM
+  */
+  const is24Hr = function (dtStr) {
+     var regex = new RegExp(/^(0?[0-9]|1[0-9]|2[0-3])(:[0-5][0-9]){1,2}$/);
+     return regex.test(dtStr);
+ }
+ 
+ /**
+  * Tests the string to see if it matches a 12 hour clock time
+  * @param {String} dtStr potential hh:MM aa string
+  * @returns {boolean} true if it matches hh:mm aa 
+  */
+ const is12Hr = function (dtStr) {
+     var regex = new RegExp(/^(0?[0-9]|1[0-2])(:[0-5][0-9]){1,2} ?[a|p|A|P]\.?[m|M]\.?$/);
+     return regex.test(dtStr);
+ }
+ 
+ /**
+  * Parses the passed in string based on it's format and converted to a ZonedDateTime.
+  * @param {String} str string number to try and parse and convert
+  * @throws Error when the string cannot be parsed
+  */
+ const parseString = function(str) {
+ 
+     // Number
+     if(!isNaN(str)) {
+         return addMillisToNow(str);
+     }
+ 
+     // ISO8601
+     else if(isISO8601(str)) {
+         throw Error('ISO 8601 strings are not yet supported');
+     }
+ 
+     // 24 hour time string
+     else if(is24Hr(str)) {
+         const parts = str.split(':');
+         return time.ZonedDateTime.now().withHour(parts[0])
+                                        .withMinute(parts[1])
+                                        .withSecond(parts[2] || 0)
+                                        .withNano(0);
+     }
+ 
+     // 12 hour time string
+     else if(is12Hr(str)) {
+         const parts = str.split(':');
+         let hr = parseInt(parts[0]);
+         hr = (str.contains('p') || str.contains('P')) ? hr + 12 : hr;
+         return time.ZonedDateTime.now().withHour(hr) 
+                                        .withMinute(parseInt(parts[1])) // parseInt will ignore the am/pm
+                                        .withSecond(parseInt(parts[2]) || 0)
+                                        .withNano(0);
+     }
+ 
+     else {
+ 
+         // Java ZonedDateTime's toString format (see monkey patched parse function)
+         try {
+             return time.ZonedDateTime.parse(str);
+         }
+ 
+         // Duration string
+         catch(e) {
+             try {
+                 return time.ZonedDateTime.now().plus(time.Duration.parse(str));
+             }
+ 
+             // Unsupported
+             catch(e) {
+                 throw Error('"' + str + '" cannot be parsed into a format that can be converted to a ZonedDateTime');
+             }
+         }
+     }
+ 
+ }
+ 
+ /**
+  * Converts the state of the passed in Item to a time.ZonedDateTime
+  * @param {items.Item} item 
+  * @returns {time.ZonedDateTime}
+  * @throws error if the Item's state is not supported or the Item itself is not supported
+  */
+ const convertItem = function(item) {
+ 
+ 
+     // Uninitialized
+     if(item.isUninitialized) {
+         throw Error('Item ' + item.name + ' is NULL or UNDEF, cannot convert to a time.ZonedDateTime');
+     }
+ 
+     // Number type Items
+     else if(item.rawState instanceof DecimalType) {
+         return addMillisToNow(item.rawState.floatValue());
+     }
+ 
+     // String type Items
+     else if(item.rawState instanceof StringType) {
+         return parseString(item.state);
+     }
+ 
+     // DateTime Items
+     else if(item.rawState instanceof DateTimeType) {
+         return javaZDTtoZDT(item.rawState.getZonedDateTime());
+     }
+ 
+     // Number:Time type Items
+     else if(item.rawState instanceof QuantityType) {
+         return addQuantityType(item.rawState);
+     }
+ 
+     else {
+         throw Error(item.type + ' is not supported for conversion to time.ZonedDateTime');
+     }
+ }
+ 
+ /**
+  * Converts the passed in when to a time.ZonedDateTime based on the following 
+  * set of rules.
+  * 
+  * - null, undefined: time.ZonedDateTime.now()
+  * - time.ZonedDateTime: unmodified
+  * - Java ZonedDateTime, DateTimeType: converted to time.ZonedDateTime equivalnet
+  * - JavaScript native Date: converted to a time.ZonedDateTime using SYSTEM as the timezone
+  * - number, bigint, Java Number, DecimalType: rounded and added to time.ZonedDateTime.now() as milliseconds
+  * - QuantityType: if the units are Time, added to now
+  * - Item: converts the state of the Item based on the *Type rules described here
+  * - String, Java String, StringType: Parsed based on the following rules
+  *     - ISO 8601: Not yet implemented
+  *     - RFC (output from a Java ZonedDateTime.toString()): parsed to time.ZonedDateTime
+  *     - HH:mm[:ss] (i.e. 24 hour time): that time with today's date (seconds are optional)
+  *     - KK:mm[:ss][ ][aa] (i.e. 12 hour time): that time with today's date (seconds and space between time and am/pm are optional)
+  *     - Duration: any duration string supported by time.Duration (e.g. 'PT5H4M3.210S'), see https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse
+  * @param {*} when any of the types discussed above
+  * @returns time.ZonedDateTime
+  * @throws error if the type, format, or contents of when are not supported
+  */
+ time.toZDT = function(when) {
+ 
+     // If when is not supplied or null, return now
+     if(when === undefined || when === null) {
+         return time.ZonedDateTime.now();
+     }
+ 
+     // Pass through if already a time.ZonedDateTime
+     else if(when instanceof time.ZonedDateTime) {
+         return when;
+     }
+ 
+     // Java ZDT
+     else if(when instanceof javaZDT) {
+         return javaZDTtoZDT(when);
+     }
+ 
+     // DateTimeType, extract the javaZDT and convert to time.ZDT
+     else if(when instanceof DateTimeType) {
+         return javaZDTtoZDT(when.getZonedDateTime());
+     }
+ 
+     // JavaScript Native Date, use the SYSTEM timezone
+     else if(when instanceof Date) {
+         const native = time.nativeJs(when);
+         const instant = time.Instant.from(native);
+         return time.ZonedDateTime.ofInstant(instant, time.ZoneId.SYSTEM);
+     }
+ 
+     // Duration, add to now
+     else if(when instanceof time.Duration || when instanceof javaDuration) {
+         return time.ZonedDateTime.now().plus(time.Duration.parse(when.toString()));
+     }
+ 
+     // JavaScript number of bigint, add as millisecs to now
+     else if(typeof when === 'number' || typeof when === 'bigint') {
+         return addMillisToNow(when);
+     }
+ 
+     // QuantityType<Time>, add to now
+     else if(when instanceof QuantityType) {
+         return addQuantityType(when);
+     }
+ 
+     // Java Number of DecimalType, add as millisecs to now
+     else if(when instanceof javaNumber || when instanceof DecimalType) {
+         return addMillisToNow(when.floatValue());
+     }
+ 
+     // String or StringType
+     else if(typeof when === 'string' || when instanceof javaString || when instanceof StringType) {
+         return parseString(when.toString());
+     }
+ 
+     // GenericItem
+     else if(when instanceof ohItem) {
+         return convertItem(items.getItem(when.name));
+     }
+ 
+     // items.Item
+     else if(when.constructor.name === 'Item') {
+         return convertItem(when);
+     }
+ 
+     // Unsupported
+     throw Error('"' + when + '" is an unsupported type for conversion to time.ZonedDateTime');
+ 
+ }
+ 
+ //openHAB uses a RFC DateTime string, js-joda defaults to the ISO version, this defaults RFC instead
+ const rfcFormatter = time.DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS[xxxx][xxxxx]");
+ const targetParse = time.ZonedDateTime.prototype.parse;
+ time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
+     return targetParse(text, formatter);
+ }
+ 
+ /**
+  * Moves the date portion of the date time to today, accounting for DST
+  */
+  time.ZonedDateTime.prototype.toToday = function () {
+     let now = time.ZonedDateTime.now();
+     return this.withYear(now.year())
+                .withMonth(now.month())
+                .withDayOfMonth(now.dayOfMonth());
+ }
+ 
+ /**
+  * Compares this ZDT to see if it falls between start and end times,
+  * accounting for times that span midnight. start and end can be any type
+  * that has a `toZonedDateTime()` method.
+  * time.toZDT is called on the arguments. Examples:
+  * 
+  * time.ZonedDateTime.now().betweenTimes(items.getItem('Sunset'), "23:30:00") // is now between sunset and 11:00 pm?
+  * time.toZDT(items.geItem('MyDateTimeItem')).betweenTimes(time.toZDT(), time.toZDT(1000)) // is the state of MyDateTimeItem between now and a second from now?
+  * 
+  * @param {*} start the starting time in anything that can be 
+  * @param {*} end the ending time
+  * @returns {Boolean} true if this is between start and end
+  */
+  time.ZonedDateTime.prototype.betweenTimes = function(start, end) {
+     start = time.toZDT(start).toLocalTime();
+     end = time.toZDT(end).toLocalTime();
+     time = this.toLocalTime();
+ 
+     // time range spans midnight
+     if(end.isBefore(start)) {
+         return (time.isAfter(start) && time.isBefore(time.LocalTime.MIDNIGHT)) 
+                || (time.isAfter(time.LocalTime.MIDNIGHT) && time.isBefore(end));
+     }
+     else {
+         return time.isAfter(start) && time.isBefore(end);
+     }
+     
+ }
+ 
+ /**
+  * Tests to see if the difference betwee this and the passed in ZoneDateTime is
+  * within the passed in maxDur.
+  * @param {time.ZonedDateTime} zdt the date tiem to compare to this
+  * @param {time.Duration} maxDur the duration to test that the difference between this and zdt is within
+  * @returns {Boolean} true if the delta between this and zdt is within maxDur
+  */
+ time.ZonedDateTime.prototype.isClose = function(zdt, maxDur) {
+     const delta = time.Duration.between(this, zdt).abs();
+     return delta.compareTo(maxDur) <= 0;
+ }
+ 
+ module.exports = time;


### PR DESCRIPTION
# [time] Time Utils

# Description

Implements a number of utilities for working with date times.

- `time.toZDT()`: converts almost anything that can reasonably be converted to a date time to a ZonedDateTime. See the docs for the rules used when converting (e.g. a number is added to now as milliseconds, '1:23 PM' returns a date time with today's date and 13:23:00 for the time, etc.).
- `zdt.toToday()`: returns a new `time.ZonedDateTime` with `zdt`'s time and today's date, accounting for DST changes.
- `zdt.betweenTimes(start, end)`: returns `true` if `zdt`'s time is between the times (ignoring date) represented by `start` and `end`. If the `end` time is before `start`, the time range is assumed to span midnight. `start` and `end` can be anything supported by `time.toZDT()`, for example `now.betweenTimes(items.getItem('Sunset'), '05:00');`.
- `zdt.isClose(otherZDT, maxDuration)`: returns true if the difference between `zdt` and `otherZDT` is within `maxDuration`.

# Testing

I used the following in a MainUI Script to test this library .

```javascript
var {testUtils} = require('openhab_rules_tools');
var {DateTimeType, DecimalType, QuantityType} = require('@runtime');
var OHItem = Java.type('org.openhab.core.items.Item');
var javaZDT = Java.type('java.time.ZonedDateTime');
var javaDur = Java.type('java.time.Duration');
var testItems = [];
var veryClose = time.Duration.ofMillis(30);
var prefix = 'TestToZDT';

var exceptionExpected = (runme) => {
  try {
    runme();
  }
  catch(e) {
    return true;
  }
  return false;
}

var testOhType = (name, type, state) => {
  items.replaceItem(name, type);
  testUtils.sleep(100);
  items.getItem(name).postUpdate(state);
  testUtils.sleep(100);
  testUtils.assert(items.getItem(name).state == state.toString());
  testItems.push(name);
}

try {
  console.info('Starting toZDT Tests')

  var testNum = 0;

  // Test 1: undefined or null
  console.info("Executing Test" + (++testNum));
  var now = time.ZonedDateTime.now();
  testUtils.assert(now.isClose(time.ZonedDateTime.now(), veryClose), 
                   'Test 1: Failed to convert undefined to now');

  // Test 2: passthrough
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(now) === now,
                  'Test 2: Failed to passthrough time.ZDT');

  // Test 3: Java ZDT
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(javaZDT.now()).isClose(time.toZDT(), veryClose),
                  'Test 3: Failed to convert Java ZDT');

  // Test 4: DateTimeType
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(new DateTimeType()).isClose(time.toZDT(), veryClose),
                  'Test 4: Failed. to convert DateTimeType');

  // Test 5: JavaScript Date
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(new Date()).isClose(time.toZDT(), veryClose),
                  'Test 5: Failed to convert JS Date');

  // Test 6: JavaScript Number
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(10).isClose(time.toZDT().plus(veryClose), veryClose),
                  'Test 6: Failed. to convert number');

  // Test 7: Java Duration
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(javaDur.ofMillis(10)).isClose(time.toZDT(10), veryClose),
                  'Test 7: Failed to convert a java Duration');

  // Test 8: time.Duration
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(veryClose).isClose(time.toZDT(10), veryClose),
                  'Test 8: Failed to convert time.Duration');

  // Test 9: DecimalType
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(new DecimalType(10)).isClose(time.toZDT(20), veryClose),
                  'Test 9: Failed to convert DecimalType');

  // Test 10: QuantityType
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT(new QuantityType('10 s')).isClose(time.toZDT(10000), veryClose),
                  'Test 10: Failed. to convert QuantityType');

  // Test 11: Unsupported units
  console.info("Executing Test" + (++testNum));
  testUtils.assert(exceptionExpected(() => time.toZDT(new QuantityType(10, '°F'))),
                  'Test 11: Failed to throw exception on unsupportted units');

  // Test 12: ISO 8601 String
  // TODO
  console.info("Executing Test" + (++testNum));

  // Test 13: 24 time
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT('13:21').isClose(time.toZDT().withHour(13).withMinute(21).withSecond(0).withNano(0), veryClose),
                  'Test 13: Failed to convert 24 hr time without seconds');
  testUtils.assert(time.toZDT('13:21:56').isClose(time.toZDT().withHour(13).withMinute(21).withSecond(56).withNano(0), veryClose),
                  'Test 13: Failed to convert 24 hr time with seconds');
  testUtils.assert(exceptionExpected(() => time.toZDT('25:00:00')),
                  'Test 13: Failed to throw exception for invalid time');

  // Test 14: 12 hr time
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT('1:21 pm').isClose(time.toZDT().withHour(13).withMinute(21).withSecond(0).withNano(0), veryClose),
                  'Test 14: Failed to convert 12 hr time without seconds');
  testUtils.assert(time.toZDT('01:21:56pm').isClose(time.toZDT().withHour(13).withMinute(21).withSecond(56).withNano(0), veryClose),
                  'Test 14: Failed to convert 12 hr time with seconds');
  testUtils.assert(exceptionExpected(() => time.toZDT('13:00:00 pm')),
                  'Test 14: Failed to throw exception for invalid time');

  // Test 15: Java ZonedDateTime.toString()
  console.info("Executing Test" + (++testNum));
  now = time.toZDT();
  javaNow = javaZDT.now();
  testUtils.assert(time.toZDT(javaNow.toString()).isClose(now, veryClose),
                  'Test 15: Failed to convert RFC string');
  
  // Test 16: Java ZonedDateTime.toString()
  console.info("Executing Test" + (++testNum));
  testUtils.assert(time.toZDT('PT10s').isClose(time.toZDT().plusSeconds(10), veryClose),
                  'Test 16: Duration String')

  // Test 17: Unsupported String
  console.info("Executing Test" + (++testNum));
  testUtils.assert(exceptionExpected(() => time.toZDT('unsupported')),
                   'Test 17: Failed to throw exception for unsupportable string');

  // Test 18: Number Item
  console.info("Executing Test" + (++testNum));
  var itemName = prefix+'Number';
  testOhType(itemName, 'Number', '1000');
  testUtils.assert(time.toZDT(items.getItem(itemName)).isClose(time.toZDT(1000), veryClose),
                  'Test 18: Failed to convert Number Item');
  testUtils.assert(time.toZDT(items.getItem(itemName).rawItem).isClose(time.toZDT(1000), veryClose),
                  'Test 18: Failed to convert raw Number Item');

  // Test 19: String Item
  console.info("Executing Test" + (++testNum));
  itemName = prefix+'String';
  testOhType(itemName, 'String', 'PT10S');
  testUtils.assert(time.toZDT(items.getItem(itemName)).isClose(time.toZDT(10000), veryClose),
                  'Test 19: Failed to convert String Item');
  testUtils.assert(time.toZDT(items.getItem(itemName).rawItem).isClose(time.toZDT(10000), veryClose),
                  'Test 19: Failed to convert raw String Item');

  // Test 20: DateTime Item
  console.info("Executing Test" + (++testNum));
  itemName = prefix+'DateTime';
  testOhType(itemName, 'DateTime', new DateTimeType().toString());
  testUtils.assert(time.toZDT(items.getItem(itemName)).isClose(time.toZDT(items.getItem(itemName).rawState), veryClose),
                  'Test 20: Failed to convert DateTimeType');
  testUtils.assert(time.toZDT(items.getItem(itemName).rawItem).isClose(time.toZDT(items.getItem(itemName).rawState), veryClose),
                  'Test 20: Failed to convert raw DateTimeType');

  // Test 21: Number:Time Item
  console.info("Executing Test" + (++testNum));
  itemName = prefix+'Quantity';
  testOhType(itemName, 'Number:Time', '10 s');
  var tdt = time.toZDT(items.getItem(itemName));
  now = time.toZDT('PT10s');
  testUtils.assert(time.toZDT(items.getItem(itemName)).isClose(time.toZDT('PT10s'), veryClose),
                  'Test 21: Failed to convert Number:Time');
  testUtils.assert(time.toZDT(items.getItem(itemName).rawItem).isClose(time.toZDT('PT10s'), veryClose),
                  'Test 21: Failed to convert raw Number:Time');

  // Test 22: Unsupported Item Type
  console.info("Executing Test" + (++testNum));
  itemName = prefix+'Switch';
  testOhType(itemName, 'Switch', 'ON');
  testUtils.assert(exceptionExpected(() => time.toZDT(items.getItem(itemName))),
                  'Test 22: Failed to throw exception for unsupported Item type');
  testUtils.assert(exceptionExpected(() => time.toZDT(items.getItem(itemName).rawItem)),
                  'Test 22: Failed to throw exception for unsupported raw Item type');

  // Test 23: toToday
  console.info("Executing Test" + (++testNum));
  var yesterday = time.toZDT().minusDays(1);
  testUtils.assert(time.toZDT().isClose(yesterday.toToday(), veryClose),
                   'Test 23: Failed to move yesterday to today');

  // Test 24: betweenTimes
  console.info("Executing Test" + (++testNum));
  now = time.toZDT();
  var before = now.withHour(20);
  var start = now.withHour(21);
  var between = now.withHour(22);
  var end = now.withHour(23);
  var after = now.withHour(3);
  testUtils.assert(!before.betweenTimes(start, end), 
                   'Test 24: Failed to find 20 outside between times');
  testUtils.assert(between.betweenTimes(start, end), 
                   'Test 24: Failed to find 22 inside between times');
  end = now.withHour(2);
  testUtils.assert(!before.betweenTimes(start, end), 
                   'Test 24: Failed spans midnight, before times');
  testUtils.assert(!after.betweenTimes(start, end), 
                   'Test 24: Failed spans midnight, after times');  
  testUtils.assert(between.betweenTimes(start, end), 
                   'Test 24: Failed spans midnight, after start before midnight');
  testUtils.assert(now.withHour(1).betweenTimes(start, end), 
                   'Test 24: Failed spans miodnight, before end after midnight');

}
catch(e) {
  console.error(`an error occured: ` + e);
}
finally {
/**
  Items apparently don't get registered, can't remove them
  testItems.forEach(i => {
    console.info('Deleting ' + i);
    items.removeItem(i);
  });
  */
}

console.log("toZDT tests are done");
```

The functions used from `testUtils` are:

```javascript
const assert = (condition, message) => {
  if(!condition) {
    throw new Error(message || 'Assertion failed');
  }
}
  
const sleep = (msec) => {
  var curr = time.ZonedDateTime.now();
  var done = curr.plus(msec, time.ChronoUnit.MILLIS);
  var timeout = curr.plusSeconds(5);
  while (curr.isBefore(done) && curr.isBefore(timeout)) { // busy wait
    curr = time.ZonedDateTime.now();
  }
  //if(curr.isAfter(timeout)) console.error('sleep timed out!');
}
```

These are a part of openhab_rules_tools.