### PR TITLE
Utils: Fix property names getters of dumpObject()

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -142,7 +142,8 @@ let dumpObject = function (obj) {
             log.info("String value = " + obj);
         }
 
-        log.info("getAllPropertyNames(obj) = {}", getAllPropertyNames(obj));
+        log.info("  getOwnPropertyNames(obj) = {}", Object.keys(obj).toString());
+        log.info("  getAllPropertyNames(obj) = {}", getAllPropertyNames(obj).toString());
         // log.info("obj.toString() = {}", obj.toString());
         // log.info("JSON.stringify(obj) = {}", JSON.stringify(obj));
     } catch(e) {


### PR DESCRIPTION
# Utils: Fix property names getters of dumpObject()
# Description

Fixes #104 and adds a getter for the object's own enumerable property
names.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>

# Testing

I have used the following UI-script for testing:
```javascript
var myObj = {
  foo: 'Hello',
  bar: 'world'
}

utils.dumpObject(myObj);
```

This logs:
```
2022-04-01 16:05:42.791 [INFO ] [org.openhab.automation.script.utils ] - Dumping object...
2022-04-01 16:05:42.792 [INFO ] [org.openhab.automation.script.utils ] -   typeof obj = object
2022-04-01 16:05:42.794 [INFO ] [org.openhab.automation.script.utils ] -   Java.isJavaObject(obj) = false
2022-04-01 16:05:42.796 [INFO ] [org.openhab.automation.script.utils ] -   Java.isType(obj) = false
2022-04-01 16:05:42.798 [INFO ] [org.openhab.automation.script.utils ] -   getOwnPropertyNames(obj) = foo,bar
2022-04-01 16:05:42.802 [INFO ] [org.openhab.automation.script.utils ] -   getAllPropertyNames(obj) = foo,bar,__proto__,constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf,__defineGetter__,__defineSetter__,__lookupGetter__,__lookupSetter__
```