### PR TITLE
[rules] Improvements for event object & JSRule callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library aims to be a fairly high-level ES6 library to support automation in
 It provides convenient access to common openHAB functionality within rules including items, things, actions, logging and more.
 
 This library is included by default in the openHAB [JavaScript
-binding](https://www.openhab.org/addons/automation/jsscripting/)
+binding](https://www.openhab.org/addons/automation/jsscripting/).
 
 - [Installation](#installation)
   - [Default Installation](#default-installation)
@@ -741,7 +741,7 @@ rules.when().item("F1_light").changed().then(event => {
     console.log(event);
 }).build("Test Rule", "My Test Rule");
 ```
-see [Examples](#rule-builder-examples) for further patterns
+See [Examples](#rule-builder-examples) for further patterns.
 
 #### Rule Builder Triggers
 
@@ -862,13 +862,13 @@ This tables gives an overview over the `event` object:
 | `eventType`       | all except `ThingStatus****Trigger`s                | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
 | `triggerType`     | all except `ThingStatus****Trigger`s                | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
 
-All properties are type of String.
+All properties are typeof `string`.
 
 **NOTE:**
 `ThingStatusUpdateTrigger`, `ThingStatusChangeTrigger` use *Thing* and `ChannelEventTrigger` uses the the trigger channel name as value for `itemName`.
 `Group****Trigger`s use the equivalent `Item****Trigger` as trigger for each member.
 
-You may use [utils.dumpObject(event)](https://openhab.github.io/openhab-js/utils.html#.dumpObject) to get all properties of an `event` object.
+See [openhab-js - EventObject](https://openhab.github.io/openhab-js/rules.html#.EventObject) for full APi documentation.
 
 ### Initialization hook: scriptLoaded
 
@@ -888,7 +888,7 @@ For file based scripts, this function will be called if found when the script is
 ```javascript
 scriptUnloaded = function () {
     console.log("script unloaded");
-    //clean up rouge timers
+    // clean up rouge timers
     clearInterval(timer);
 }
 ```

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -5,6 +5,29 @@
  * @namespace rules
  */
 
+/**
+ * @typedef {Object} EventObject When a rule is triggered, the script is provided the event instance that triggered it. The specific data depends on the event type. The {@link EventObject} provides several information about that trigger.
+ * @memberof rules
+ * @property {String} oldState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: Previous state of Item or Group that triggered event
+ * @property {String} newState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: New state of Item or Group that triggered event
+ * @property {String} state only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State of Item that triggered event
+ * @property {String} receivedCommand only for {@link triggers.ItemCommandTrigger} & {@link triggers.GroupCommandTrigger}: Command that triggered event
+ * @property {String} receivedState only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State that triggered event
+ * @property {*} receivedTrigger only for {@link triggers.ChannelEventTrigger}: Trigger that triggered event
+ * @property {String} itemName for all triggers: Name of Item that triggered event
+ * @property {String} eventType for all triggers except ThingStatus****Triggers: Type of event that triggered event (change, command, time, triggered, update)
+ * @property {String} triggerType for all triggers except ThingStatus****Triggers: Type of trigger that triggered event (for TimeOfDayTrigger: GenericCronTrigger)
+ * @property {*} payload not for all triggers
+ */
+
+/**
+ * @callback RuleCallback When a rule is run, a callback is executed.
+ * @memberof rules
+ * @param {rules.EventObject} event
+ * @param {*} input raw Java input from the Rule Engine, sometimes required for advances use cases
+ * @param {*} module raw Java input from the Rule Engine, sometimes required for advances use cases
+ */
+
 const GENERATED_RULE_ITEM_TAG = 'GENERATED_RULE_ITEM';
 
 const items = require('../items');
@@ -178,14 +201,14 @@ const setEnabled = function (uid, isEnabled) {
   *  name: "my_new_rule",
   *  description: "this rule swizzles the swallows",
   *  triggers: triggers.GenericCronTrigger("0 30 16 * * ? *"),
-  *  execute: triggerConfig => { //do stuff }
+  *  execute: (event) => { // do stuff }
   * });
   *
   * @memberOf rules
   * @param {Object} ruleConfig The rule config describing the rule
   * @param {String} ruleConfig.name the name of the rule
   * @param {String} [ruleConfig.description] a description of the rule
-  * @param {*} ruleConfig.execute callback that will be called when the rule fires
+  * @param {rules.RuleCallback} ruleConfig.execute callback that will be called when the rule fires
   * @param {HostTrigger|HostTrigger[]} ruleConfig.triggers triggers which will define when to fire the rule
   * @param {String} [ruleConfig.id] the UID of the rule
   * @param {Array<String>} [ruleConfig.tags] the tags for the rule
@@ -300,7 +323,7 @@ const registerRule = function (rule) {
   * @param {Object} ruleConfig The rule config describing the rule
   * @param {String} ruleConfig.name the name of the rule
   * @param {String} [ruleConfig.description] a description of the rule
-  * @param {*} ruleConfig.execute callback that will be called when the rule fires
+  * @param {rules.RuleCallback} ruleConfig.execute callback that will be called when the rule fires
   * @param {HostTrigger|HostTrigger[]} ruleConfig.triggers triggers which will define when to fire the rule
   * @param {String} [ruleConfig.id] the UID of the rule
   * @param {Array<String>} [ruleConfig.tags] the tags for the rule

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -19,18 +19,17 @@
  * @property {String} receivedCommand only for {@link triggers.ItemCommandTrigger} & {@link triggers.GroupCommandTrigger}: Command that triggered event
  * @property {String} receivedState only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State that triggered event
  * @property {*} receivedTrigger only for {@link triggers.ChannelEventTrigger}: Trigger that triggered event
- * @property {String} itemName for all triggers: Name of Item that triggered event
- * @property {String} eventType for all triggers except `ThingStatus****Triggers`: Type of event that triggered event (change, command, time, triggered, update)
- * @property {String} triggerType for all triggers except `ThingStatus****Triggers`: Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`)
+ * @property {String} itemName for all triggers except {@link triggers.PWMTrigger}: name of Item that triggered event
+ * @property {String} eventType for all triggers except `ThingStatus****Triggers`, {@link triggers.PWMTrigger}: Type of event that triggered event (change, command, time, triggered, update)
+ * @property {String} triggerType for all triggers except `ThingStatus****Triggers`, {@link triggers.PWMTrigger}: Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`)
  * @property {*} payload not for all triggers
+ * @property {String} command only for {@link triggers.PWMTrigger}: Pulse Width Modulation Automation command
  */
 
 /**
  * @callback RuleCallback When a rule is run, a callback is executed.
  * @memberof rules
  * @param {rules.EventObject} event
- * @param {*} input raw Java input from the Rule Engine, sometimes required for advances use cases
- * @param {*} module raw Java input from the Rule Engine, sometimes required for advances use cases
  */
 
 const GENERATED_RULE_ITEM_TAG = 'GENERATED_RULE_ITEM';
@@ -237,7 +236,7 @@ const JSRule = function (ruleConfig) {
 
   const doExecute = function (module, input) {
     try {
-      return ruleConfig.execute(getTriggeredData(input), input, module);
+      return ruleConfig.execute(getTriggeredData(input));
     } catch (error) {
       // logging error is required for meaningful error log message
       // when throwing error: error is caught by core framework and no meaningful message is logged
@@ -406,7 +405,8 @@ const getTriggeredData = function (input) {
     receivedState: null,
     receivedTrigger: null,
     itemName: evArr[0].toString(),
-    module: input.get('module')
+    module: input.get('module'),
+    command: input.get('command') + '' // for PWM trigger
   };
 
   try {

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -6,7 +6,12 @@
  */
 
 /**
- * @typedef {Object} EventObject When a rule is triggered, the script is provided the event instance that triggered it. The specific data depends on the event type. The {@link EventObject} provides several information about that trigger.
+ * @typedef {Object} EventObject When a rule is triggered, the script is provided the event instance that triggered it. The specific data depends on the event type. The `EventObject` provides several information about that trigger.
+ *
+ * Note:
+ * `ThingStatusUpdateTrigger`, `ThingStatusChangeTrigger` use *Thing* and `ChannelEventTrigger` uses the the trigger channel name as value for `itemName`.
+ * `Group****Trigger`s use the equivalent `Item****Trigger` as trigger for each member.
+ *
  * @memberof rules
  * @property {String} oldState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: Previous state of Item or Group that triggered event
  * @property {String} newState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: New state of Item or Group that triggered event
@@ -15,8 +20,8 @@
  * @property {String} receivedState only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State that triggered event
  * @property {*} receivedTrigger only for {@link triggers.ChannelEventTrigger}: Trigger that triggered event
  * @property {String} itemName for all triggers: Name of Item that triggered event
- * @property {String} eventType for all triggers except ThingStatus****Triggers: Type of event that triggered event (change, command, time, triggered, update)
- * @property {String} triggerType for all triggers except ThingStatus****Triggers: Type of trigger that triggered event (for TimeOfDayTrigger: GenericCronTrigger)
+ * @property {String} eventType for all triggers except `ThingStatus****Triggers`: Type of event that triggered event (change, command, time, triggered, update)
+ * @property {String} triggerType for all triggers except `ThingStatus****Triggers`: Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`)
  * @property {*} payload not for all triggers
  */
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -351,10 +351,10 @@ const getTriggeredData = function (input) {
     return {
       eventType: 'command',
       triggerType: 'ItemCommandTrigger',
-      receivedCommand: event.getItemCommand(),
+      receivedCommand: event.getItemCommand().toString(),
       oldState: input.get('oldState') + '',
       newState: input.get('newState') + '',
-      itemName: event.getItemName(),
+      itemName: event.getItemName().toString(),
       module: input.get('module')
     };
   }
@@ -377,7 +377,7 @@ const getTriggeredData = function (input) {
     receivedCommand: null,
     receivedState: null,
     receivedTrigger: null,
-    itemName: evArr[0],
+    itemName: evArr[0].toString(),
     module: input.get('module')
   };
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -209,7 +209,7 @@ const JSRule = function (ruleConfig) {
 
   const doExecute = function (module, input) {
     try {
-      return ruleConfig.execute(getTriggeredData(input));
+      return ruleConfig.execute(getTriggeredData(input), input, module);
     } catch (error) {
       // logging error is required for meaningful error log message
       // when throwing error: error is caught by core framework and no meaningful message is logged


### PR DESCRIPTION
This PR fixes #124.

## Enhancements
-  `JSRule execute` callback: Allow access to raw Java input.
- `event` object: Make all properties typeof `string`.
- Document both callback and `event` object in JSDoc.

## Possible breaking changes
- The `receivedCommand` property of the `event` object is now typeof `string`, before it was the raw Java command type.