### PR TITLE
[items] Improve docs for replaceItem & itemConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,10 @@ items.replaceItem({
   type: 'Switch',
   name: 'MySwitch',
   metadata: {
-    config: {
-      pattern: '%s'
+    stateDescription: {
+      config: {
+        pattern: '%s'
+      }
     }
   }
 });

--- a/README.md
+++ b/README.md
@@ -321,11 +321,13 @@ Calling `addItem(itemConfig)` or `replaceItem(itemConfig)` requires the `itemCon
     * .groupFunction ⇒ <code>String</code>
 
 Note: `.type` and `.name` are required.
+Basic UI and the mobile apps need `metadata.stateDescription.config.pattern` to render the state of an Item.
 
 Example:
 ```javascript
+// more advanced example
 items.replaceItem({
-  type: 'Switch',
+  type: 'String',
   name: 'Hallway_Light',
   label: 'Hallway Light',
   category: 'light',
@@ -338,15 +340,22 @@ items.replaceItem({
     }
   },
   metadata: {
-    expire: '10m,command=OFF',
+    expire: '10m,command=1',
     stateDescription: {
       config: {
         pattern: '%d%%',
-        min: 0,
-        max: 100,
-        step: 1,
         options: '1=Red, 2=Green, 3=Blue'
       }
+    }
+  }
+});
+// minimal example
+items.replaceItem({
+  type: 'Switch',
+  name: 'MySwitch',
+  metadata: {
+    config: {
+      pattern: '%s'
     }
   }
 });

--- a/README.md
+++ b/README.md
@@ -361,7 +361,8 @@ items.replaceItem({
 });
 ```
 
-See [openhab-js : items](https://openhab.github.io/openhab-js/items.html) for full API documentation.
+See [openhab-js : ItemConfig](https://openhab.github.io/openhab-js/items.html#.ItemConfig) for full API documentation.
+
 #### `item.history`
 Calling `item.history` returns a ItemHistory object with the following functions:
 

--- a/items/managed.js
+++ b/items/managed.js
@@ -11,22 +11,32 @@ const itemBuilderFactory = osgi.getService('org.openhab.core.items.ItemBuilderFa
 const managedItemProvider = osgi.getService('org.openhab.core.items.ManagedItemProvider');
 
 /**
- * @namespace items
+ * @typedef ItemConfig configuration describing an Item
+ * @memberof items
+ * @property {String} type the type of the Item
+ * @property {String} name Item name for the Item to create
+ * @property {String} [label] the label for the Item
+ * @property {String} [category] the category (icon) for the Item
+ * @property {String[]} [groups] an array of groups the Item is a member of
+ * @property {String[]} [tags] an array of tags for the Item
+ * @property {String|Object} [channels] for single channel link a string or for multiple an object { channeluid: configuration }; configuration is an object
+ * @property {items.ItemMetadata} [metadata] either object { namespace: value } or { namespace: { value: value, config: {} } }
+ * @property {String} [giBaseType] the group Item base type for the Item
+ * @property {HostGroupFunction} [groupFunction] the group function used by the Item
  */
 
 /**
- * @typedef ItemConfig configuration describing an Item
+ * @typedef ItemMetadata Item metadata configuration, not fully documented
  * @memberof items
- * @property {String} itemConfig.type the type of the Item
- * @property {String} itemConfig.name Item name for the Item to create
- * @property {String} [itemConfig.label] the label for the Item
- * @property {String} [itemConfig.category] the category (icon) for the Item
- * @property {String[]} [itemConfig.groups] an array of groups the Item is a member of
- * @property {String[]} [itemConfig.tags] an array of tags for the Item
- * @property {String|Object} [itemConfig.channels] for single channel link a string or for multiple an object { channeluid: configuration }; configuration is an object
- * @property {Object} [itemConfig.metadata] either object { namespace: value } or { namespace: { value: value, config: {} } }, `stateDescription.config.pattern` is required for state rendering in Basic UI and the mobile apps
- * @property {HostItem} [itemConfig.giBaseType] the group Item base type for the Item
- * @property {HostGroupFunction} [itemConfig.groupFunction] the group function used by the Item
+ * @property {Object} [stateDescription] `stateDescription` configuration, required for most UIs
+ * @property {Object} [stateDescription.config] config of this metadata namespace
+ * @property {String} [stateDescription.config.pattern] state formatting pattern, required for most UIs, see {@link https://www.openhab.org/docs/configuration/items.html#state-presentation}
+ * @property {Object} [expire] `expire` configuration, see {@link https://www.openhab.org/docs/configuration/items.html#parameter-expire}
+ * @property {String} [expire.value] e.g. `0h30m0s,command=OFF`
+ * @property {Object} [expire.config]
+ * @property {String} [expire.config.ignoreStateUpdates] If the ignore state updates checkbox is set, only state changes will reset the timer; `true` or `false`
+ * @property {Object} [autoupdate] `autoupdate` configuration, see {@link https://www.openhab.org/docs/configuration/items.html#parameter-expire}
+ * @property {String} [autoupdate.value] `true` or `false`
  */
 
 /**
@@ -321,17 +331,10 @@ class Item {
  *
  * @memberof items
  * @private
- * @param {Object} itemConfig the Item config describing the Item
+ * @param {items.ItemConfig} itemConfig the Item config describing the Item
  * @param {String} itemConfig.type the type of the Item
- * @param {String} itemConfig.name Item name for the Item to create
- * @param {String} [itemConfig.label] the label for the Item
- * @param {String} [itemConfig.category] the category (icon) for the Item
- * @param {String[]} [itemConfig.groups] an array of groups the Item is a member of
- * @param {String[]} [itemConfig.tags] an array of tags for the Item
- * @param {HostItem} [itemConfig.giBaseType] the group Item base type for the Item
- * @param {HostGroupFunction} [itemConfig.groupFunction] the group function used by the Item
  * @returns {Item} an {@link items.Item} object
- * @throws itemConfig.name or itemConfig.type not set
+ * @throws {@link items.ItemConfig.name} or {@link items.ItemConfig.type} not set
  * @throws failed to create Item
  */
 const createItem = function (itemConfig) {
@@ -471,7 +474,7 @@ const removeItem = function (itemOrItemName) {
  *
  * This function can be useful in scripts which create a static set of items which may need updating either
  * periodically, during startup or even during development of the script. Using fixed item names will ensure
- * that the items remain up-to-date, but won't fail with issues related to duplicate items. 
+ * that the items remain up-to-date, but won't fail with issues related to duplicate items.
  *
  * @memberof items
  * @param {items.ItemConfig} itemConfig the Item config describing the Item

--- a/items/managed.js
+++ b/items/managed.js
@@ -15,6 +15,21 @@ const managedItemProvider = osgi.getService('org.openhab.core.items.ManagedItemP
  */
 
 /**
+ * @typedef ItemConfig configuration describing an Item
+ * @memberof items
+ * @property {String} itemConfig.type the type of the Item
+ * @property {String} itemConfig.name Item name for the Item to create
+ * @property {String} [itemConfig.label] the label for the Item
+ * @property {String} [itemConfig.category] the category (icon) for the Item
+ * @property {String[]} [itemConfig.groups] an array of groups the Item is a member of
+ * @property {String[]} [itemConfig.tags] an array of tags for the Item
+ * @property {String|Object} [itemConfig.channels] for single channel link a string or for multiple an object { channeluid: configuration }; configuration is an object
+ * @property {Object} [itemConfig.metadata] either object { namespace: value } or { namespace: { value: value, config: {} } }, `stateDescription.config.pattern` is required for state rendering in Basic UI and the mobile apps
+ * @property {HostItem} [itemConfig.giBaseType] the group Item base type for the Item
+ * @property {HostGroupFunction} [itemConfig.groupFunction] the group function used by the Item
+ */
+
+/**
  * Tag value to be attached to all dynamically created items.
  *
  * @memberof items
@@ -369,19 +384,10 @@ const createItem = function (itemConfig) {
  * created with the value {@link DYNAMIC_ITEM_TAG}.
  *
  * @memberof items
- * @param {Object} itemConfig the Item config describing the Item
- * @param {String} itemConfig.type the type of the Item
- * @param {String} itemConfig.name Item name for the Item to create
- * @param {String} [itemConfig.label] the label for the Item
- * @param {String} [itemConfig.category] the category (icon) for the Item
- * @param {String[]} [itemConfig.groups] an array of groups the Item is a member of
- * @param {String[]} [itemConfig.tags] an array of tags for the Item
- * @param {String|Object} [itemConfig.channels] for single channel link a string or for multiple an object { channeluid: configuration }; configuration is an object
- * @param {Object} [itemConfig.metadata] either object { namespace: value } or { namespace: { value: value, config: {} } }
- * @param {HostItem} [itemConfig.giBaseType] the group Item base type for the Item
- * @param {HostGroupFunction} [itemConfig.groupFunction] the group function used by the Item
+ * @memberof items
+ * @param {items.ItemConfig} itemConfig the Item config describing the Item
  * @returns {Item} an {@link items.Item} object
- * @throws itemConfig.name or itemConfig.type not set
+ * @throws {@link items.ItemConfig.name} or {@link items.ItemConfig.type} not set
  * @throws failed to create Item
  */
 const addItem = function (itemConfig) {
@@ -465,22 +471,12 @@ const removeItem = function (itemOrItemName) {
  *
  * This function can be useful in scripts which create a static set of items which may need updating either
  * periodically, during startup or even during development of the script. Using fixed item names will ensure
- * that the items remain up-to-date, but won't fail with issues related to duplicate items.
+ * that the items remain up-to-date, but won't fail with issues related to duplicate items. 
  *
  * @memberof items
- * @param {Object} itemConfig the Item config describing the Item
- * @param {String} itemConfig.type the type of the Item
- * @param {String} itemConfig.name Item name for the Item to create
- * @param {String} [itemConfig.label] the label for the Item
- * @param {String} [itemConfig.category] the category (icon) for the Item
- * @param {String[]} [itemConfig.groups] an array of groups the Item is a member of
- * @param {String[]} [itemConfig.tags] an array of tags for the Item
- * @param {String|Object} [itemConfig.channels] for single channel link a string or for multiple an object { channeluid: configuration }; configuration is an object
- * @param {Object} [itemConfig.metadata] either object { namespace: value } or { namespace: { value: value, config: {} } }
- * @param {HostItem} [itemConfig.giBaseType] the group Item base type for the Item
- * @param {HostGroupFunction} [itemConfig.groupFunction] the group function used by the Item
+ * @param {items.ItemConfig} itemConfig the Item config describing the Item
  * @returns {Item} an {@link items.Item} object
- * @throws itemConfig.name or itemConfig.type not set
+ * @throws {@link items.ItemConfig.name} or {@link items.ItemConfig.type} not set
  * @throws failed to create Item
  */
 const replaceItem = function (itemConfig) {


### PR DESCRIPTION
Refers to #118.

Improvements:
* Mentions in the README that `stateDescription` is required for Basic UI & the mobile apps.
* Improve JSDoc for `itemConfig` and `ItemMetadata`.
* Fix duplicate `@namespace items` JSDoc tags.