### PR TITLE
[rules] Refactor EventObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 2.0.0 (to be released)
+
+| Type        | Namespace | Description                                              | Reference                                      | Breaking |
+|-------------|-----------|----------------------------------------------------------|------------------------------------------------|----------|
+| Bugfix      | rules     | Failed rule run logs a useful error message              | https://github.com/openhab/openhab-js/pull/116 | No       |
+| Enhancement | utils     | Allow `dumpObject` to also dump own properties           | https://github.com/openhab/openhab-js/pull/121 | No       |
+| Bugfix      | rules     | Fix `removeItem` not working                             | https://github.com/openhab/openhab-js/pull/122 | No       |
+| Enhancement | triggers  | Add PWM Automation trigger                               | https://github.com/openhab/openhab-js/pull/126 | No       |
+| Enhancement | triggers  | Add PID Automation trigger                               | https://github.com/openhab/openhab-js/pull/131 | No       |
+| Enhancement | things    | Add Thing class & add `getThing`(s)                      | https://github.com/openhab/openhab-js/pull/132 | No       |
+| Enhancement | rules     | Refactor EventObject to only hold properties with values | TODO                                           | **Yes**      |
+
+Also see the [PR Milestone](https://github.com/openhab/openhab-js/milestone/1).
+
+## 1.2.3
+
+Changelog is incomplete!
+
+| Namespace | Description                                                        | Reference                                      | Breaking |
+|-----------|--------------------------------------------------------------------|------------------------------------------------|----------|
+| items     | `addItem(...)` and `updateItem(...)` use `itemConfig` as parameter | https://github.com/openhab/openhab-js/pull/109 | **Yes**      |
+| time      | Add timeUtils                                                      | https://github.com/openhab/openhab-js/pull/101 | No       |
+
+
+## 1.2.2
+
+Changelog is incomplete!
+
+| Namespace | Description                                                         | Reference                                     | Breaking |
+|-----------|---------------------------------------------------------------------|-----------------------------------------------|----------|
+| items     | item.history.lastUpdate() returns `ZonedDateTime` instead of `Date` | https://github.com/openhab/openhab-js/pull/67 | **Yes**      |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 | Enhancement | triggers  | Add PWM Automation trigger                               | https://github.com/openhab/openhab-js/pull/126 | No       |
 | Enhancement | triggers  | Add PID Automation trigger                               | https://github.com/openhab/openhab-js/pull/131 | No       |
 | Enhancement | things    | Add Thing class & add `getThing`(s)                      | https://github.com/openhab/openhab-js/pull/132 | No       |
-| Enhancement | rules     | Refactor EventObject to only hold properties with values | TODO                                           | **Yes**      |
+| Enhancement | rules     | Refactor EventObject to only hold properties with values | TODO                                           | **Yes**  |
 
-Also see the [PR Milestone](https://github.com/openhab/openhab-js/milestone/1).
+Also see the [Release Milestone](https://github.com/openhab/openhab-js/milestone/1).
 
 ## 1.2.3
 
@@ -20,7 +20,7 @@ Changelog is incomplete!
 
 | Namespace | Description                                                        | Reference                                      | Breaking |
 |-----------|--------------------------------------------------------------------|------------------------------------------------|----------|
-| items     | `addItem(...)` and `updateItem(...)` use `itemConfig` as parameter | https://github.com/openhab/openhab-js/pull/109 | **Yes**      |
+| items     | `addItem(...)` and `updateItem(...)` use `itemConfig` as parameter | https://github.com/openhab/openhab-js/pull/109 | **Yes**  |
 | time      | Add timeUtils                                                      | https://github.com/openhab/openhab-js/pull/101 | No       |
 
 
@@ -30,4 +30,4 @@ Changelog is incomplete!
 
 | Namespace | Description                                                         | Reference                                     | Breaking |
 |-----------|---------------------------------------------------------------------|-----------------------------------------------|----------|
-| items     | item.history.lastUpdate() returns `ZonedDateTime` instead of `Date` | https://github.com/openhab/openhab-js/pull/67 | **Yes**      |
+| items     | item.history.lastUpdate() returns `ZonedDateTime` instead of `Date` | https://github.com/openhab/openhab-js/pull/67 | **Yes**  |

--- a/README.md
+++ b/README.md
@@ -900,22 +900,25 @@ The specific data depends on the event type.
 The `event` object provides several information about that trigger.
 
 This tables gives an overview over the `event` object:
-| Property Name     | Trigger Types                                       | Description                                                                         | Rules DSL Equivalent   |
-|-------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
-| `oldState`        | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | Previous state of Item or Group that triggered event                                | `previousState`        |
-| `newState`        | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | New state of Item or Group that triggered event                                     | N/A                    |
-| `state`           | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State of Item that triggered event                                                  | `triggeringItem.state` |
-| `receivedCommand` | `ItemCommandTrigger`, `GroupCommandTrigger`         | Command that triggered event                                                        | `receivedCommand`      |
-| `receivedState`   | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State that triggered event                                                          | N/A                    |
-| `receivedTrigger` | `ChannelEventTrigger`                               | Trigger that triggered event                                                        | N/A                    |
-| `itemName`        | all                                                 | Name of Item that triggered event                                                   | `triggeringItem.name`  |
-| `eventType`       | all except `ThingStatus****Trigger`s                | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
-| `triggerType`     | all except `ThingStatus****Trigger`s                | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
+| Property Name                | Trigger Types                                       | Description                                                                         | Rules DSL Equivalent   |
+|------------------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
+| `oldState`                   | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | Previous state of Item or Group that triggered event                                | `previousState`        |
+| `newState`                   | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | New state of Item or Group that triggered event                                     | N/A                    |
+| `state`, `receivedState`     | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State of Item that triggered event                                                  | `triggeringItem.state` |
+| `command`, `receivedCommand` | `ItemCommandTrigger`, `GroupCommandTrigger`         | Command that triggered event                                                        | `receivedCommand`      |
+| `itemName`                   | `Item****Trigger`                                   | Name of Item that triggered event                                                   | `triggeringItem.name`  |
+| `receivedEvent`              | `ChannelEventTrigger`                               | Channel event that triggered event                                                  | N/A                    |
+| `channelUID`                 | `ChannelEventTrigger`                               | UID of channel that triggered event                                                 | N/A                    |
+| `oldStatus`                  | `ThingStatusChangeTrigger`                          | Previous state of Thing that triggered event                                        | N/A                    |
+| `newStatus`                  | `ThingStatusChangeTrigger`                          | New state of Thing that triggered event                                             | N/A                    |
+| `status`                     | `ThingStatusUpdateTrigger`                          | State of Thing that triggered event                                                 | N/A                    |
+| `thingUID`                   | `Thing****Trigger`                                  | UID of Thing that triggered event                                                   | N/A                    |
+| `eventType`                  | all                                                 | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
+| `triggerType`                | all                                                 | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
 
 All properties are typeof `string`.
 
 **NOTE:**
-`ThingStatusUpdateTrigger`, `ThingStatusChangeTrigger` use *Thing* and `ChannelEventTrigger` uses the the trigger channel name as value for `itemName`.
 `Group****Trigger`s use the equivalent `Item****Trigger` as trigger for each member.
 
 See [openhab-js : EventObject](https://openhab.github.io/openhab-js/rules.html#.EventObject) for full API documentation.

--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ This tables gives an overview over the `event` object:
 | `status`                     | `ThingStatusUpdateTrigger`                          | State of Thing that triggered event                                                 | N/A                    |
 | `thingUID`                   | `Thing****Trigger`                                  | UID of Thing that triggered event                                                   | N/A                    |
 | `eventType`                  | all                                                 | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
-| `triggerType`                | all                                                 | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
+| `triggerType`                | all except `PWMTrigger`, `PIDTrigger`               | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
 
 All properties are typeof `string`.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ binding](https://www.openhab.org/addons/automation/jsscripting/).
   - [Default Installation](#default-installation)
   - [Custom Installation](#custom-installation)
   - [Configuration](#configuration)
-- [Latest Changes](#latest-changes)
-  - [Breaking Changes](#breaking-changes)
 - [UI Based Rules](#ui-based-rules)
   - [Adding Triggers](#adding-triggers)
   - [Adding Actions](#adding-actions)
@@ -65,12 +63,6 @@ NPM will create a `node_modules` directory containing the latest version of this
 This will be used instead of the binding provided version.
 
 ### Configuration
-
-## Latest Changes
-
-### Breaking Changes
-- item.history.lastUpdate() returns `ZonedDateTime` instead of `Date`
-- `addItem(...)` and `updateItem(...)` use [`itemConfig`](#itemconfig) as parameter
 
 ## UI Based Rules
 

--- a/README.md
+++ b/README.md
@@ -892,21 +892,21 @@ The specific data depends on the event type.
 The `event` object provides several information about that trigger.
 
 This tables gives an overview over the `event` object:
-| Property Name                | Trigger Types                                       | Description                                                                         | Rules DSL Equivalent   |
-|------------------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
-| `oldState`                   | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | Previous state of Item or Group that triggered event                                | `previousState`        |
-| `newState`                   | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | New state of Item or Group that triggered event                                     | N/A                    |
-| `state`, `receivedState`     | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State of Item that triggered event                                                  | `triggeringItem.state` |
-| `command`, `receivedCommand` | `ItemCommandTrigger`, `GroupCommandTrigger`         | Command that triggered event                                                        | `receivedCommand`      |
-| `itemName`                   | `Item****Trigger`                                   | Name of Item that triggered event                                                   | `triggeringItem.name`  |
-| `receivedEvent`              | `ChannelEventTrigger`                               | Channel event that triggered event                                                  | N/A                    |
-| `channelUID`                 | `ChannelEventTrigger`                               | UID of channel that triggered event                                                 | N/A                    |
-| `oldStatus`                  | `ThingStatusChangeTrigger`                          | Previous state of Thing that triggered event                                        | N/A                    |
-| `newStatus`                  | `ThingStatusChangeTrigger`                          | New state of Thing that triggered event                                             | N/A                    |
-| `status`                     | `ThingStatusUpdateTrigger`                          | State of Thing that triggered event                                                 | N/A                    |
-| `thingUID`                   | `Thing****Trigger`                                  | UID of Thing that triggered event                                                   | N/A                    |
-| `eventType`                  | all                                                 | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
-| `triggerType`                | all except `PWMTrigger`, `PIDTrigger`               | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
+| Property Name            | Trigger Types                                       | Description                                                                         | Rules DSL Equivalent   |
+|--------------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
+| `oldState`               | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | Previous state of Item or Group that triggered event                                | `previousState`        |
+| `newState`               | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | New state of Item or Group that triggered event                                     | N/A                    |
+| `state`, `receivedState` | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State of Item that triggered event                                                  | `triggeringItem.state` |
+| `receivedCommand`        | `ItemCommandTrigger`, `GroupCommandTrigger`         | Command that triggered event                                                        | `receivedCommand`      |
+| `itemName`               | `Item****Trigger`                                   | Name of Item that triggered event                                                   | `triggeringItem.name`  |
+| `receivedEvent`          | `ChannelEventTrigger`                               | Channel event that triggered event                                                  | N/A                    |
+| `channelUID`             | `ChannelEventTrigger`                               | UID of channel that triggered event                                                 | N/A                    |
+| `oldStatus`              | `ThingStatusChangeTrigger`                          | Previous state of Thing that triggered event                                        | N/A                    |
+| `newStatus`              | `ThingStatusChangeTrigger`                          | New state of Thing that triggered event                                             | N/A                    |
+| `status`                 | `ThingStatusUpdateTrigger`                          | State of Thing that triggered event                                                 | N/A                    |
+| `thingUID`               | `Thing****Trigger`                                  | UID of Thing that triggered event                                                   | N/A                    |
+| `eventType`              | all                                                 | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
+| `triggerType`            | all except `PWMTrigger`, `PIDTrigger`               | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
 
 All properties are typeof `string`.
 

--- a/README.md
+++ b/README.md
@@ -892,21 +892,21 @@ The specific data depends on the event type.
 The `event` object provides several information about that trigger.
 
 This tables gives an overview over the `event` object:
-| Property Name            | Trigger Types                                       | Description                                                                         | Rules DSL Equivalent   |
-|--------------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
-| `oldState`               | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | Previous state of Item or Group that triggered event                                | `previousState`        |
-| `newState`               | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | New state of Item or Group that triggered event                                     | N/A                    |
-| `state`, `receivedState` | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State of Item that triggered event                                                  | `triggeringItem.state` |
-| `receivedCommand`        | `ItemCommandTrigger`, `GroupCommandTrigger`         | Command that triggered event                                                        | `receivedCommand`      |
-| `itemName`               | `Item****Trigger`                                   | Name of Item that triggered event                                                   | `triggeringItem.name`  |
-| `receivedEvent`          | `ChannelEventTrigger`                               | Channel event that triggered event                                                  | N/A                    |
-| `channelUID`             | `ChannelEventTrigger`                               | UID of channel that triggered event                                                 | N/A                    |
-| `oldStatus`              | `ThingStatusChangeTrigger`                          | Previous state of Thing that triggered event                                        | N/A                    |
-| `newStatus`              | `ThingStatusChangeTrigger`                          | New state of Thing that triggered event                                             | N/A                    |
-| `status`                 | `ThingStatusUpdateTrigger`                          | State of Thing that triggered event                                                 | N/A                    |
-| `thingUID`               | `Thing****Trigger`                                  | UID of Thing that triggered event                                                   | N/A                    |
-| `eventType`              | all                                                 | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
-| `triggerType`            | all except `PWMTrigger`, `PIDTrigger`               | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
+| Property Name     | Trigger Types                                       | Description                                                                         | Rules DSL Equivalent   |
+|-------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------|------------------------|
+| `oldState`        | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | Previous state of Item or Group that triggered event                                | `previousState`        |
+| `newState`        | `ItemStateChangeTrigger`, `GroupStateChangeTrigger` | New state of Item or Group that triggered event                                     | N/A                    |
+| `receivedState`   | `ItemStateUpdateTrigger`, `GroupStateUpdateTrigger` | State of Item that triggered event                                                  | `triggeringItem.state` |
+| `receivedCommand` | `ItemCommandTrigger`, `GroupCommandTrigger`         | Command that triggered event                                                        | `receivedCommand`      |
+| `itemName`        | `Item****Trigger`                                   | Name of Item that triggered event                                                   | `triggeringItem.name`  |
+| `receivedEvent`   | `ChannelEventTrigger`                               | Channel event that triggered event                                                  | N/A                    |
+| `channelUID`      | `ChannelEventTrigger`                               | UID of channel that triggered event                                                 | N/A                    |
+| `oldStatus`       | `ThingStatusChangeTrigger`                          | Previous state of Thing that triggered event                                        | N/A                    |
+| `newStatus`       | `ThingStatusChangeTrigger`                          | New state of Thing that triggered event                                             | N/A                    |
+| `status`          | `ThingStatusUpdateTrigger`                          | State of Thing that triggered event                                                 | N/A                    |
+| `thingUID`        | `Thing****Trigger`                                  | UID of Thing that triggered event                                                   | N/A                    |
+| `eventType`       | all                                                 | Type of event that triggered event (change, command, time, triggered, update)       | N/A                    |
+| `triggerType`     | all except `PWMTrigger`, `PIDTrigger`               | Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`) | N/A                    |
 
 All properties are typeof `string`.
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -14,7 +14,6 @@
  * @memberof rules
  * @property {String} oldState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: Previous state of Item or Group that triggered event
  * @property {String} newState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: New state of Item or Group that triggered event
- * @property {String} state only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State of Item that triggered event
  * @property {String} receivedState only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State that triggered event
  * @property {String} receivedCommand only for {@link triggers.ItemCommandTrigger}, {@link triggers.GroupCommandTrigger}, {@link triggers.PWMTrigger} & {@link triggers.PIDTrigger} : Command that triggered event
  * @property {String} itemName for all triggers except {@link triggers.PWMTrigger}: name of Item that triggered event

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -448,6 +448,16 @@ const getTriggeredData = function (input) {
         data.receivedEvent = event.getEvent();
         data.eventType = 'triggered';
         data.triggerType = 'ChannelEventTrigger';
+        Object.defineProperty(
+          data,
+          'receivedTrigger',
+          {
+            get: function () {
+              console.warn('"receivedTrigger" has been deprecated and will be removed in a future release. Please use "receivedEvent" instead.');
+              return event.getEvent();
+            }
+          }
+        );
         break;
     }
     data.eventClass = Java.typeName(event.class);

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -398,10 +398,7 @@ const getTriggeredData = function (input) {
   if (input.containsKey('command')) data.receivedCommand = input.get('command').toString();
   addFromHashMap(input, 'oldState', data);
   addFromHashMap(input, 'newState', data);
-  if (input.containsKey('state')) {
-    data.receivedState = input.get('state').toString();
-    data.state = input.get('state').toString();
-  }
+  if (input.containsKey('state')) data.receivedState = input.get('state').toString();
 
   // Thing triggers
   addFromHashMap(input, 'oldStatus', data);
@@ -425,6 +422,16 @@ const getTriggeredData = function (input) {
         data.itemName = event.getItemName();
         data.eventType = 'update';
         data.triggerType = 'ItemStateUpdateTrigger';
+        Object.defineProperty(
+          data,
+          'state',
+          {
+            get: function () {
+              console.warn('"state" has been deprecated and will be removed in a future release. Please use "receivedState" instead.');
+              return input.get('state').toString();
+            }
+          }
+        );
         break;
       case 'org.openhab.core.thing.events.ThingStatusInfoChangedEvent':
         data.thingUID = event.getThingUID().toString();

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -372,6 +372,18 @@ const SwitchableJSRule = function (ruleConfig) {
 };
 
 /**
+ * Adds a key's value from a Java HashMap to a JavaScript object (as string) if the HashMap has that key.
+ * This function uses the mutable nature of JS objects and does not return anything.
+ * @private
+ * @param {*} hashMap Java HashMap
+ * @param {String} key key from the HashMap to add to the JS object
+ * @param {Object} object JavaScript object
+ */
+const addFromHashMap = (hashMap, key, object) => {
+  if (hashMap.containsKey(key)) object[key] = hashMap[key].toString();
+};
+
+/**
  * Get rule trigger data from raw Java input and generate JavaScript object.
  * @private
  * @param {*} input raw Java input from openHAB core
@@ -388,17 +400,17 @@ const getTriggeredData = function (input) {
     data.receivedCommand = input.get('command').toString();
     data.command = input.get('command').toString();
   }
-  if (input.containsKey('oldState')) data.oldState = input.get('oldState').toString();
-  if (input.containsKey('newState')) data.newState = input.get('newState').toString();
+  addFromHashMap(input, 'oldState', data);
+  addFromHashMap(input, 'newState', data);
   if (input.containsKey('state')) {
     data.receivedState = input.get('state').toString();
     data.state = input.get('state').toString();
   }
 
   // Thing triggers
-  if (input.containsKey('newStatus')) data.newStatus = input.get('newStatus').toString();
-  if (input.containsKey('oldStatus')) data.oldStatus = input.get('oldStatus').toString();
-  if (input.containsKey('status')) data.status = input.get('status').toString();
+  addFromHashMap(input, 'oldStatus', data);
+  addFromHashMap(input, 'newStatus', data);
+  addFromHashMap(input, 'status', data);
 
   // Only with event data (for Item, Thing & Channel triggers)
   if (event) {
@@ -447,7 +459,7 @@ const getTriggeredData = function (input) {
   }
 
   // Always
-  if (input.containsKey('module')) data.module = input.get('module');
+  addFromHashMap(input, 'module', data);
 
   // If the ScriptEngine gets an empty input, the trigger is either time based or the rule is run manually!!
   if (input.size() === 0) {

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -372,7 +372,7 @@ const SwitchableJSRule = function (ruleConfig) {
 };
 
 /**
- * Get rule trigger data from raw Java input and generate JavScript object.
+ * Get rule trigger data from raw Java input and generate JavaScript object.
  * @private
  * @param {*} input raw Java input from openHAB core
  * @returns {rules.EventObject}

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -459,9 +459,8 @@ const getTriggeredData = function (input) {
 
   // If the ScriptEngine gets an empty input, the trigger is either time based or the rule is run manually!!
   if (input.size() === 0) {
-    data.eventType = 'time';
-    data.triggerType = 'GenericCronTrigger';
-    data.triggerTypeOld = 'TimerTrigger';
+    data.eventType = '';
+    data.triggerType = '';
   }
 
   return data;

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -16,7 +16,6 @@
  * @property {String} newState only for {@link triggers.ItemStateChangeTrigger} & {@link triggers.GroupStateChangeTrigger}: New state of Item or Group that triggered event
  * @property {String} state only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State of Item that triggered event
  * @property {String} receivedState only for {@link triggers.ItemStateUpdateTrigger} & {@link triggers.GroupStateUpdateTrigger}: State that triggered event
- * @property {String} command only for {@link triggers.ItemCommandTrigger}, {@link triggers.GroupCommandTrigger}, {@link triggers.PWMTrigger} & {@link triggers.PIDTrigger} : Command that triggered event
  * @property {String} receivedCommand only for {@link triggers.ItemCommandTrigger}, {@link triggers.GroupCommandTrigger}, {@link triggers.PWMTrigger} & {@link triggers.PIDTrigger} : Command that triggered event
  * @property {String} itemName for all triggers except {@link triggers.PWMTrigger}: name of Item that triggered event
  * @property {String} receivedEvent only for {@link triggers.ChannelEventTrigger}: Channel event that triggered event
@@ -396,10 +395,7 @@ const getTriggeredData = function (input) {
   // Properties of data are dynamically added, depending on their availability
 
   // Item triggers
-  if (input.containsKey('command')) {
-    data.receivedCommand = input.get('command').toString();
-    data.command = input.get('command').toString();
-  }
+  if (input.containsKey('command')) data.receivedCommand = input.get('command').toString();
   addFromHashMap(input, 'oldState', data);
   addFromHashMap(input, 'newState', data);
   if (input.containsKey('state')) {

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -9,7 +9,6 @@
  * @typedef {Object} EventObject When a rule is triggered, the script is provided the event instance that triggered it. The specific data depends on the event type. The `EventObject` provides several information about that trigger.
  *
  * Note:
- * `ThingStatusUpdateTrigger`, `ThingStatusChangeTrigger` use *Thing* and `ChannelEventTrigger` uses the the trigger channel name as value for `itemName`.
  * `Group****Trigger`s use the equivalent `Item****Trigger` as trigger for each member.
  *
  * @memberof rules
@@ -26,14 +25,8 @@
  * @property {String} newStatus only for {@link triggers.ThingStatusChangeTrigger}: New state of Thing that triggered event
  * @property {String} status only for {@link triggers.ThingStatusUpdateTrigger}: State of Thing that triggered event
  * @property {String} eventType for all triggers except {@link triggers.PWMTrigger}, {@link triggers.PIDTrigger}: Type of event that triggered event (change, command, time, triggered, update)
- * @property {String} triggerType for all triggers: Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`)
+ * @property {String} triggerType for all triggers except {@link triggers.PWMTrigger}, {@link triggers.PIDTrigger}: Type of trigger that triggered event (for `TimeOfDayTrigger`: `GenericCronTrigger`)
  * @property {*} payload for most triggers
- */
-
-/**
- * @callback RuleCallback When a rule is run, a callback is executed.
- * @memberof rules
- * @param {rules.EventObject} event
  */
 
 const GENERATED_RULE_ITEM_TAG = 'GENERATED_RULE_ITEM';
@@ -200,6 +193,25 @@ const setEnabled = function (uid, isEnabled) {
 };
 
 /**
+ * @callback RuleCallback When a rule is run, a callback is executed.
+ * @memberof rules
+ * @param {rules.EventObject} event
+ */
+
+/**
+ * @typedef RuleConfig configuration for {@link rules.JSRule}
+ * @memberof rules
+ * @property {String} name name of the rule (used in UI)
+ * @property {String} [description] description of the rule (used in UI)
+ * @property {triggers|triggers[]} triggers which will fire the rule
+ * @property {rules.RuleCallback} execute callback to run when the rule fires
+ * @property {String} [id] UID of the rule, if not provided, one is generated
+ * @property {String[]} [tags] tags for the rule (used in UI)
+ * @property {String} ruleGroup name of rule group to use
+ * @property {Boolean} [overwrite=false] whether to overwrite an existing rule with the same UID
+ */
+
+/**
   * Creates a rule. The rule will be created and immediately available.
   *
   * @example
@@ -213,15 +225,7 @@ const setEnabled = function (uid, isEnabled) {
   * });
   *
   * @memberOf rules
-  * @param {Object} ruleConfig The rule config describing the rule
-  * @param {String} ruleConfig.name the name of the rule
-  * @param {String} [ruleConfig.description] a description of the rule
-  * @param {rules.RuleCallback} ruleConfig.execute callback that will be called when the rule fires
-  * @param {HostTrigger|HostTrigger[]} ruleConfig.triggers triggers which will define when to fire the rule
-  * @param {String} [ruleConfig.id] the UID of the rule
-  * @param {Array<String>} [ruleConfig.tags] the tags for the rule
-  * @param {String} [ruleConfig.ruleGroup] the name of the rule group to use
-  * @param {Boolean} [ruleConfig.overwrite=false] overwrite an existing rule with the same UID
+  * @param {rules.RuleConfig} ruleConfig The rule config describing the rule
   * @returns {HostRule} the created rule
   * @throws Will throw an error if the rule with the passed in uid already exists
   */
@@ -328,15 +332,7 @@ const registerRule = function (rule) {
   * The rule will be created and immediately available.
   *
   * @memberOf rules
-  * @param {Object} ruleConfig The rule config describing the rule
-  * @param {String} ruleConfig.name the name of the rule
-  * @param {String} [ruleConfig.description] a description of the rule
-  * @param {rules.RuleCallback} ruleConfig.execute callback that will be called when the rule fires
-  * @param {HostTrigger|HostTrigger[]} ruleConfig.triggers triggers which will define when to fire the rule
-  * @param {String} [ruleConfig.id] the UID of the rule
-  * @param {Array<String>} [ruleConfig.tags] the tags for the rule
-  * @param {String} [ruleConfig.ruleGroup] the name of the rule group to use
-  * @param {Boolean} [ruleConfig.overwrite=false] overwrite an existing rule with the same UID
+  * @param {rules.RuleConfig} ruleConfig The rule config describing the rule
   * @returns {HostRule} the created rule
   * @throws Will throw an error is a rule with the given UID already exists.
   */
@@ -375,6 +371,12 @@ const SwitchableJSRule = function (ruleConfig) {
   }
 };
 
+/**
+ * Get rule trigger data from raw Java input and generate JavScript object.
+ * @private
+ * @param {*} input raw Java input from openHAB core
+ * @returns {rules.EventObject}
+ */
 const getTriggeredData = function (input) {
   const event = input.get('event');
   const data = {};

--- a/triggers.js
+++ b/triggers.js
@@ -243,7 +243,7 @@ const TimeOfDayTrigger = (time, triggerName) => createTrigger('timer.TimeOfDayTr
  *     triggers.PWMTrigger('pwm_dimmer', 10)
  *   ],
  *   execute: (event) => {
- *     items.getItem('pwm_switch').sendCommand(event.command);
+ *     items.getItem('pwm_switch').sendCommand(event.receivedCommand);
  *   }
  * });
  *
@@ -274,7 +274,7 @@ const PWMTrigger = (dutycycleItem, interval, minDutyCycle, maxDutyCycle, deadMan
  *   ],
  *   execute: (event) => {
  *     // Look out what the max value for your Item is!
- *     const command = parseInt(event.command) > 100 ? '100' : event.command;
+ *     const command = parseInt(event.receivedCommand) > 100 ? '100' : event.receivedCommand;
  *     items.getItem('thermostat').sendCommand(command);
  *   }
  * });


### PR DESCRIPTION
This PR refactors the `getTriggeredData` method in `rules/rules.js`.
Except the changes listed under breaking changes, all properties from the old EventObject are retained, but new ones added.

## Improvements
The EventObject now only has properties which have a value and there are no more null strings added for properties which have no value.
This allows the user to perform checks like `event.itemName === undefined` for undefined check which were prevously not possible due to an issue described in #134.

Furthermore, I added a CHANGELOG.md.

## Breaking Changes
- for `ChannelEventTrigger`: `receivedTrigger` has been marked as deprecated
- for `ItemStateUpdateEvent` & `GroupStateUpdateEvent`: `state` has been marked as deprecated
- for `ChannelEventTrigger`: the `ChanelUID` of the channel that triggered the rule is now in the `channelUID` property and not in the `itemName` property
- for `ThingStatus***Trigger`: the `ThingUID` of the Thing that triggered the rule is now in the `thingUID` property and not in the `itemName` property

## Testing
I have tested the new event object for all triggers we currently suppport and everything works as expected. My production system is in fact already using this refactoring and until now I have not encountered any problems.