### PR TITLE
[WIP] [rules] Add support for displaying the code in  MainUI

### DIFF
--- a/rules/rules.js
+++ b/rules/rules.js
@@ -283,6 +283,11 @@ const JSRule = function (ruleConfig) {
     rule = registerRule(rule);
   }
 
+  // Add config to the action so that MainUI can show the script
+  const actionConfiguration = rule.actions.get(0).configuration;
+  actionConfiguration.put('type', 'application/javascript;version=ECMAScript-2021');
+  actionConfiguration.put('script', '// Code to run when the rule fires:\n' + ruleConfig.execute.toString());
+
   return rule;
 };
 


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/12929.

## Description

With this PR, the `JSRule` API adds additional information to the rule‘s action, so that MainUI is able to display a rule‘s source code.
Due to the lack of direct access to the rules source code, a utility function is used to regenerate the source code from the given rule configuration.
Therefore, the generated code does not work for the `RuleBuilder` API, as this is using `JSRule` under the hood.

## Testing

This PR requires additional testing from my side, as well as an update of the type defintions.