### PR TITLE
Add `js-quantities` for units of measurement handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .DS_Store
 .vscode
 .idea
+coverage
 dist
 docs
 node_modules
 openhab-*.tgz
 out
-coverage
+types/quantities.*

--- a/index.js
+++ b/index.js
@@ -29,5 +29,6 @@ module.exports = {
   get utils () { return require('./utils'); },
   get osgi () { return require('./osgi'); },
   get cache () { return require('./cache'); },
-  get time () { return require('./time'); }
+  get time () { return require('./time'); },
+  get Quantity () { return require('js-quantities'); }
 };

--- a/index.js
+++ b/index.js
@@ -30,5 +30,5 @@ module.exports = {
   get osgi () { return require('./osgi'); },
   get cache () { return require('./cache'); },
   get time () { return require('./time'); },
-  get Quantity () { return require('js-quantities'); }
+  get Quantity () { return require('./quantities'); }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
             "dependencies": {
                 "@js-joda/core": "^4.3.1",
                 "@js-joda/timezone": "^2.11.1",
+                "js-quantities": "^1.7.6",
                 "parse-duration": "^0.1.1"
             },
             "devDependencies": {
                 "@types/jest": "^28.1.8",
+                "@types/js-quantities": "^1.6.3",
                 "acorn": "^8.6.0",
                 "docdash": "^1.2.0",
                 "jest": "^28.1.3",
@@ -1674,6 +1676,12 @@
                 "expect": "^28.0.0",
                 "pretty-format": "^28.0.0"
             }
+        },
+        "node_modules/@types/js-quantities": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@types/js-quantities/-/js-quantities-1.6.3.tgz",
+            "integrity": "sha512-YwBhHz9Ad7GH/hvg8P9qoKoqG5+xYsM2AQpb96jCDS9HbIj3m24RPgoY2xKPUd5LYAIkaL26igRQQrETf4Gwxg==",
+            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.9",
@@ -6344,6 +6352,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/js-quantities": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.7.6.tgz",
+            "integrity": "sha512-h6TH1xK1u/zdjD26M6kKVthZONJSDTIRzrohbqOILfJAyanWHGlJLWuAWkSMtqi8k/IxshStsc97Pkf8SL9yvA=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -11042,6 +11055,12 @@
                 "pretty-format": "^28.0.0"
             }
         },
+        "@types/js-quantities": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@types/js-quantities/-/js-quantities-1.6.3.tgz",
+            "integrity": "sha512-YwBhHz9Ad7GH/hvg8P9qoKoqG5+xYsM2AQpb96jCDS9HbIj3m24RPgoY2xKPUd5LYAIkaL26igRQQrETf4Gwxg==",
+            "dev": true
+        },
         "@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -14938,6 +14957,11 @@
                     }
                 }
             }
+        },
+        "js-quantities": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.7.6.tgz",
+            "integrity": "sha512-h6TH1xK1u/zdjD26M6kKVthZONJSDTIRzrohbqOILfJAyanWHGlJLWuAWkSMtqi8k/IxshStsc97Pkf8SL9yvA=="
         },
         "js-tokens": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@js-joda/core": "^4.3.1",
         "@js-joda/timezone": "^2.11.1",
+        "js-quantities": "^1.7.6",
         "parse-duration": "^0.1.1"
     },
     "scripts": {
@@ -29,6 +30,7 @@
     },
     "devDependencies": {
         "@types/jest": "^28.1.8",
+        "@types/js-quantities": "^1.6.3",
         "acorn": "^8.6.0",
         "docdash": "^1.2.0",
         "jest": "^28.1.3",

--- a/quantities.js
+++ b/quantities.js
@@ -1,9 +1,25 @@
 const Qty = require('js-quantities');
 
-// Polyfill support for additional unit notations
+// Polyfill support for additional unit notations and additional units as well
 // Use absolute temperature units here to allow conversion of measured temperatures
 const replaceUnits = (value) => {
   if (typeof value === 'string') {
+    // Add support for °dH (Deutscher Härtegrad) for AmountOfSubstance
+    if (value.endsWith('°dH')) {
+      // See https://www.internetchemie.info/chemie-lexikon/d/deutscher-haertegrad.php (german) for the equation/math
+      let dh = parseFloat(value);
+      if (isNaN(dh)) dh = 1;
+      const mmol_l = dh * 0.1783; // eslint-disable-line camelcase
+      return mmol_l + ' mmol/l'; // eslint-disable-line camelcase
+    }
+    // Add support for DU (Dobson Unit) for ArealDensity
+    if (value.endsWith('DU')) {
+      // See https://de.wikipedia.org/wiki/Dobson-Einheit (german) for the equation/math
+      let du = parseFloat(value);
+      if (isNaN(du)) du = 1;
+      const mmol_m2 = du * 0.44615; // eslint-disable-line camelcase
+      return mmol_m2 + ' mmol/m^2'; // eslint-disable-line camelcase
+    }
     return value
       .replace(/(°|° )C/, 'tempC')
       .replace(/(°|° )F/, 'tempF')

--- a/quantities.js
+++ b/quantities.js
@@ -1,5 +1,12 @@
 const Qty = require('js-quantities');
 
+/**
+ * Quantity namespace.
+ * This namespace exports the [js-quantities library](https://www.npmjs.com/package/js-quantities) to simplify the handling of units for calculations involving quantities and [`QuantityType`](https://www.openhab.org/javadoc/latest/org/openhab/core/library/types/quantitytype)s.
+ *
+ * @namespace Quantity
+ */
+
 // Polyfill support for additional unit notations and additional units as well
 // Use absolute temperature units here to allow conversion of measured temperatures
 const replaceUnits = (value) => {

--- a/quantities.js
+++ b/quantities.js
@@ -13,7 +13,7 @@ const replaceUnits = (value) => {
       .replace('lea', 'league') // Imperial length unit
       .replace('ɡₙ', 'gee') // Acceleration: Standard Gravity
       .replace('Ws', 'W*s') // Energy: Watt Seconds
-      .replace(/VArh/i, 'VAr*h') // Energy: Volt-Ampere Reactive Hours
+      .replace(/varh/i, 'var*h') // Energy: Volt-Ampere Reactive Hours
       .replace('lx', 'lux') // Illuminance: Lux
       .replace(/(dBm)(W)?/, 'dB*mW') // Power: Decibel-Milliwatts
       .replace('VAh', 'VA*h'); // Power: Volt-Ampere Hours

--- a/quantities.js
+++ b/quantities.js
@@ -1,18 +1,25 @@
 const Qty = require('js-quantities');
 
+// Polyfill support for additional unit notations
 // Use absolute temperature units here to allow conversion of measured temperatures
 const replaceUnits = (value) => {
-    if (typeof value === 'string') {
-        return value
-            .replace(/(°|° )C/, 'tempC')
-            .replace(/(°|° )F/, 'tempF')
-            .replace('K', 'tempK')
-            .replace('°', 'degree');
-    } else {
-        return value;
-    }
+  if (typeof value === 'string') {
+    return value
+      .replace(/(°|° )C/, 'tempC')
+      .replace(/(°|° )F/, 'tempF')
+      .replace('K', 'tempK')
+      .replace('°', 'degree')
+      .replace('fur', 'furlong') // Imperial length unit
+      .replace('lea', 'league') // Imperial length unit
+      .replace('ɡₙ', 'gee') // Acceleration: Standard Gravity
+      .replace('Ws', 'W*s') // Energy: Watt Seconds
+      .replace(/VArh/i, 'VAr*h') // Energy: Volt-Ampere Reactive Hours
+      .replace('lx', 'lux') // Illuminance: Lux
+      .replace(/(dBm)(W)?/, 'dB*mW') // Power: Decibel-Milliwatts
+      .replace('VAh', 'VA*h'); // Power: Volt-Ampere Hours
+  } else {
+    return value;
+  }
 };
 
-// Polyfill support for temperature units with the degree sign ° with or without a space in between, e.g. °C or °F
-// Polyfill support for angle in degrees using the degree sign °
 module.exports = (initValue, initUnits) => Qty(replaceUnits(initValue), replaceUnits(initUnits));

--- a/quantities.js
+++ b/quantities.js
@@ -1,0 +1,18 @@
+const Qty = require('js-quantities');
+
+// Use absolute temperature units here to allow conversion of measured temperatures
+const replaceUnits = (value) => {
+    if (typeof value === 'string') {
+        return value
+            .replace(/(°|° )C/, 'tempC')
+            .replace(/(°|° )F/, 'tempF')
+            .replace('K', 'tempK')
+            .replace('°', 'degree');
+    } else {
+        return value;
+    }
+};
+
+// Polyfill support for temperature units with the degree sign ° with or without a space in between, e.g. °C or °F
+// Polyfill support for angle in degrees using the degree sign °
+module.exports = (initValue, initUnits) => Qty(replaceUnits(initValue), replaceUnits(initUnits));

--- a/quantities.js
+++ b/quantities.js
@@ -20,6 +20,22 @@ const replaceUnits = (value) => {
       const mmol_m2 = du * 0.44615; // eslint-disable-line camelcase
       return mmol_m2 + ' mmol/m^2'; // eslint-disable-line camelcase
     }
+    // Add support for Second Angle (arc second) for Angle
+    if (value.endsWith('\'\'')) {
+      // See https://en.wikipedia.org/wiki/Minute_and_second_of_arc for the equation/math
+      let arcsecond = parseFloat(value);
+      if (isNaN(arcsecond)) arcsecond = 1;
+      const degree = arcsecond / 3600;
+      return degree + ' deg';
+    }
+    // Add support for Minute Angle (arc minute) for Angle
+    if (value.endsWith('\'')) {
+      // See https://en.wikipedia.org/wiki/Minute_and_second_of_arc for the equation/math
+      let arcminute = parseFloat(value);
+      if (isNaN(arcminute)) arcminute = 1;
+      const degree = arcminute / 60;
+      return degree + ' deg';
+    }
     return value
       .replace(/(°|° )C/, 'tempC')
       .replace(/(°|° )F/, 'tempF')

--- a/test/quantities.spec.js
+++ b/test/quantities.spec.js
@@ -2,7 +2,7 @@ const Quantity = require('../quantities');
 const Qty = require('js-quantities');
 
 /*
-Test whether js-quantities/our polyfill supports all default units from openHAB UoM.
+Test whether js-quantities/the polyfill supports all base units from openHAB UoM.
 openHAB UoM definitions are based on https://next.openhab.org/docs/concepts/units-of-measurement.html#list-of-units and converted with https://tableconvert.com/markdown-to-json.
 */
 describe('quantities.js', function () {
@@ -37,17 +37,17 @@ describe('quantities.js', function () {
       ['Acceleration', 'Metre per Second squared', 'm/s^2'],
       ['Acceleration', 'Standard Gravity', 'ɡₙ'],
       ['AmountOfSubstance', 'Mole', 'mol'],
-      ['AmountOfSubstance', 'Deutscher Härtegrad', '°dH'],
+      // Unsupported ['AmountOfSubstance', 'Deutscher Härtegrad', '°dH'],
       ['Angle', 'Radian', 'rad'],
       ['Angle', 'Degree', '°'],
-      ['Angle', 'Minute Angle', "'"],
-      ['Angle', 'Second Angle', "''"],
+      // Unsupported ['Angle', 'Minute Angle', "'"],
+      // Unsupported ['Angle', 'Second Angle', "''"],
       ['Area', 'Square Metre', 'm^2'],
-      ['ArealDensity', 'Dobson Unit', 'DU'],
+      // Unsupported ['ArealDensity', 'Dobson Unit', 'DU'],
       ['CatalyticActivity', 'Katal', 'kat'],
       ['DataAmount', 'Bit', 'bit'],
       ['DataAmount', 'Byte', 'B'],
-      ['DataAmount', 'Octet', 'o'],
+      // Unsupported ['DataAmount', 'Octet', 'o'],
       ['DataTransferRate', 'Bit per Second', 'bit/s'],
       ['Density', 'Gram per cubic Metre', 'g/m^3'],
       ['Dimensionless', 'Percent', '%'],
@@ -94,7 +94,7 @@ describe('quantities.js', function () {
       ['Speed', 'Knot', 'kn'],
       ['Temperature', 'Kelvin', 'K'],
       ['Temperature', 'Celsius', '°C'],
-      ['Temperature[^](#mired-footnote)', 'Mired', 'mired'],
+      // Unsupported ['Temperature', 'Mired', 'mired'],
       ['Time', 'Second', 's'],
       ['Time', 'Minute', 'min'],
       ['Time', 'Hour', 'h'],

--- a/test/quantities.spec.js
+++ b/test/quantities.spec.js
@@ -37,13 +37,13 @@ describe('quantities.js', function () {
       ['Acceleration', 'Metre per Second squared', 'm/s^2'],
       ['Acceleration', 'Standard Gravity', 'ɡₙ'],
       ['AmountOfSubstance', 'Mole', 'mol'],
-      // Unsupported ['AmountOfSubstance', 'Deutscher Härtegrad', '°dH'],
+      ['AmountOfSubstance', 'Deutscher Härtegrad', '°dH'],
       ['Angle', 'Radian', 'rad'],
       ['Angle', 'Degree', '°'],
       // Unsupported ['Angle', 'Minute Angle', "'"],
       // Unsupported ['Angle', 'Second Angle', "''"],
       ['Area', 'Square Metre', 'm^2'],
-      // Unsupported ['ArealDensity', 'Dobson Unit', 'DU'],
+      ['ArealDensity', 'Dobson Unit', 'DU'],
       ['CatalyticActivity', 'Katal', 'kat'],
       ['DataAmount', 'Bit', 'bit'],
       ['DataAmount', 'Byte', 'B'],
@@ -130,6 +130,18 @@ describe('quantities.js', function () {
       it('returns a Quantity.', () => {
         expect(Quantity('1' + symbol) instanceof Qty).toBe(true);
       });
+    });
+  });
+
+  describe('additional unit works as expected', () => {
+    it('of type AmountOfSubstance with unit Deutscher Härtegrad and symbol °dH', () => {
+      expect(Quantity('1 °dH').to('mmol/l').toString()).toBe('0.1783 mmol/l');
+      expect(Quantity('1.5 °dH').to('mol/l').toString()).toBe('0.00026745 mol/l');
+    });
+
+    it('of type ArealDensity with unit Dobson Unit and symbol DU', () => {
+      expect(Quantity('1 DU').to('mmol/m^2').toString()).toBe('0.44615 mmol/m2');
+      expect(Quantity('1.5 DU').to('mol/m^2').toString()).toBe('0.000669225 mol/m2');
     });
   });
 });

--- a/test/quantities.spec.js
+++ b/test/quantities.spec.js
@@ -118,4 +118,18 @@ describe('quantities.js', function () {
       });
     });
   });
+
+  describe('supports some additional units', () => {
+    const custom = [
+      ['Density', 'Kilogram per cubic metre', 'kg/m^3']
+    ];
+    describe.each(custom)('of type %s with unit %s and symbol %s', (type, unit, symbol) => {
+      it('doesn\'t throw Qty.Error.', () => {
+        expect(() => Quantity('1 ' + symbol)).not.toThrowError(Qty.Error);
+      });
+      it('returns a Quantity.', () => {
+        expect(Quantity('1' + symbol) instanceof Qty).toBe(true);
+      });
+    });
+  });
 });

--- a/test/quantities.spec.js
+++ b/test/quantities.spec.js
@@ -40,8 +40,8 @@ describe('quantities.js', function () {
       ['AmountOfSubstance', 'Deutscher Härtegrad', '°dH'],
       ['Angle', 'Radian', 'rad'],
       ['Angle', 'Degree', '°'],
-      // Unsupported ['Angle', 'Minute Angle', "'"],
-      // Unsupported ['Angle', 'Second Angle', "''"],
+      ['Angle', 'Minute Angle', "'"],
+      ['Angle', 'Second Angle', "''"],
       ['Area', 'Square Metre', 'm^2'],
       ['ArealDensity', 'Dobson Unit', 'DU'],
       ['CatalyticActivity', 'Katal', 'kat'],
@@ -134,14 +134,28 @@ describe('quantities.js', function () {
   });
 
   describe('additional unit works as expected', () => {
+    it('of type Angel with unit Minute Angel and symbol \'', () => {
+      expect(Quantity('1 \'').to('degree').toPrec('0.0001 deg').toString()).toBe('0.0167 deg');
+      expect(Quantity('1.5 \'').to('degree').toPrec('0.0001 deg').toString()).toBe('0.025 deg');
+      expect(Quantity('1 °').to(Quantity('\'')).toString()).toBe('1 deg');
+    });
+
+    it('of type Angel with unit Second Angel and symbol \'\'', () => {
+      expect(Quantity('1 \'\'').to('degree').toPrec('0.000001 deg').toString()).toBe('0.000278 deg');
+      expect(Quantity('1.5 \'\'').to('degree').toPrec('0.000001 deg').toString()).toBe('0.000417 deg');
+      expect(Quantity('1 °').to(Quantity('\'\'')).toString()).toBe('1 deg');
+    });
+
     it('of type AmountOfSubstance with unit Deutscher Härtegrad and symbol °dH', () => {
       expect(Quantity('1 °dH').to('mmol/l').toString()).toBe('0.1783 mmol/l');
       expect(Quantity('1.5 °dH').to('mol/l').toString()).toBe('0.00026745 mol/l');
+      expect(Quantity('1 mmol/l').to(Quantity('°dH')).toString()).toBe('1 mmol/l');
     });
 
     it('of type ArealDensity with unit Dobson Unit and symbol DU', () => {
       expect(Quantity('1 DU').to('mmol/m^2').toString()).toBe('0.44615 mmol/m2');
       expect(Quantity('1.5 DU').to('mol/m^2').toString()).toBe('0.000669225 mol/m2');
+      expect(Quantity('1 mol/m^2').to(Quantity('DU')).toString()).toBe('1000 mmol/m2');
     });
   });
 });

--- a/test/quantities.spec.js
+++ b/test/quantities.spec.js
@@ -1,0 +1,121 @@
+const Quantity = require('../quantities');
+const Qty = require('js-quantities');
+
+/*
+Test whether js-quantities/our polyfill supports all default units from openHAB UoM.
+openHAB UoM definitions are based on https://next.openhab.org/docs/concepts/units-of-measurement.html#list-of-units and converted with https://tableconvert.com/markdown-to-json.
+*/
+describe('quantities.js', function () {
+  describe('supports imperial base unit', () => {
+    const imperial = [
+      ['Length', 'Inch', 'in'],
+      ['Length', 'Foot', 'ft'],
+      ['Length', 'Yard', 'yd'],
+      ['Length', 'Chain', 'ch'],
+      ['Length', 'Furlong', 'fur'],
+      ['Length', 'Mile', 'mi'],
+      ['Length', 'League', 'lea'],
+      ['Pressure', 'Inch of Mercury', 'inHg'],
+      ['Pressure', 'Pound per square inch', 'psi'],
+      ['Speed', 'Miles per Hour', 'mph'],
+      ['Temperature', 'Fahrenheit', '°F'],
+      ['Volume', 'Gallon (US)', 'gal'],
+      ['VolumetricFlowRate', 'Gallon (US) per minute', 'gal/min']
+    ];
+    describe.each(imperial)('of type %s with unit %s and symbol %s', (type, unit, symbol) => {
+      it('doesn\'t throw Qty.Error.', () => {
+        expect(() => Quantity('1 ' + symbol)).not.toThrowError(Qty.Error);
+      });
+      it('returns a Quantity.', () => {
+        expect(Quantity('1' + symbol) instanceof Qty).toBe(true);
+      });
+    });
+  });
+
+  describe('supports SI base unit', () => {
+    const si = [
+      ['Acceleration', 'Metre per Second squared', 'm/s^2'],
+      ['Acceleration', 'Standard Gravity', 'ɡₙ'],
+      ['AmountOfSubstance', 'Mole', 'mol'],
+      ['AmountOfSubstance', 'Deutscher Härtegrad', '°dH'],
+      ['Angle', 'Radian', 'rad'],
+      ['Angle', 'Degree', '°'],
+      ['Angle', 'Minute Angle', "'"],
+      ['Angle', 'Second Angle', "''"],
+      ['Area', 'Square Metre', 'm^2'],
+      ['ArealDensity', 'Dobson Unit', 'DU'],
+      ['CatalyticActivity', 'Katal', 'kat'],
+      ['DataAmount', 'Bit', 'bit'],
+      ['DataAmount', 'Byte', 'B'],
+      ['DataAmount', 'Octet', 'o'],
+      ['DataTransferRate', 'Bit per Second', 'bit/s'],
+      ['Density', 'Gram per cubic Metre', 'g/m^3'],
+      ['Dimensionless', 'Percent', '%'],
+      ['Dimensionless', 'Parts per Million', 'ppm'],
+      ['Dimensionless', 'Decibel', 'dB'],
+      ['ElectricPotential', 'Volt', 'V'],
+      ['ElectricCapacitance', 'Farad', 'F'],
+      ['ElectricCharge', 'Coulomb', 'C'],
+      ['ElectricCharge', 'Ampere Hour', 'Ah'],
+      ['ElectricConductance', 'Siemens', 'S'],
+      ['ElectricConductivity', 'Siemens per Metre', 'S/m'],
+      ['ElectricCurrent', 'Ampere', 'A'],
+      ['ElectricInductance', 'Henry', 'H'],
+      ['ElectricResistance', 'Ohm', 'Ω'],
+      ['Energy', 'Joule', 'J'],
+      ['Energy', 'Watt Second', 'Ws'],
+      ['Energy', 'Watt Hour', 'Wh'],
+      ['Energy', 'Volt-Ampere Hour', 'VAh'],
+      ['Energy', 'Volt-Ampere Reactive Hour', 'varh'],
+      ['Force', 'Newton', 'N'],
+      ['Frequency', 'Hertz', 'Hz'],
+      ['Illuminance', 'Lux', 'lx'],
+      ['Intensity', 'Irradiance', 'W/m^2'],
+      ['Intensity', 'Microwatt per square Centimeter', 'µW/cm^2'],
+      ['Length', 'Metre', 'm'],
+      ['LuminousFlux', 'Lumen', 'lm'],
+      ['LuminousIntensity', 'Candela', 'cd'],
+      ['MagneticFlux', 'Weber', 'Wb'],
+      ['MagneticFluxDensity', 'Tesla', 'T'],
+      ['Mass', 'Gram', 'g'],
+      ['Power', 'Watt', 'W'],
+      ['Power', 'Volt-Ampere', 'VA'],
+      ['Power', 'Volt-Ampere Reactive', 'var'],
+      ['Power', 'Decibel-Milliwatts', 'dBm'],
+      ['Pressure', 'Pascal', 'Pa'],
+      ['Pressure', 'Hectopascal', 'hPa'],
+      ['Pressure', 'Millimetre of Mercury', 'mmHg'],
+      ['Pressure', 'Bar', 'bar'],
+      ['Radioactivity', 'Becquerel', 'Bq'],
+      ['RadiationDoseAbsorbed', 'Gray', 'Gy'],
+      ['RadiationDoseEffective', 'Sievert', 'Sv'],
+      ['SolidAngle', 'Steradian', 'sr'],
+      ['Speed', 'Metre per Second', 'm/s'],
+      ['Speed', 'Knot', 'kn'],
+      ['Temperature', 'Kelvin', 'K'],
+      ['Temperature', 'Celsius', '°C'],
+      ['Temperature[^](#mired-footnote)', 'Mired', 'mired'],
+      ['Time', 'Second', 's'],
+      ['Time', 'Minute', 'min'],
+      ['Time', 'Hour', 'h'],
+      ['Time', 'Day', 'd'],
+      ['Time', 'Week', 'week'],
+      ['Time', 'Year', 'y'],
+      ['Volume', 'Litre', 'l'],
+      ['Volume', 'Cubic Metre', 'm^3'],
+      ['VolumetricFlowRate', 'Litre per Minute', 'l/min'],
+      ['VolumetricFlowRate', 'Cubic Metre per Second', 'm^3/s'],
+      ['VolumetricFlowRate', 'Cubic Metre per Minute', 'm^3/min'],
+      ['VolumetricFlowRate', 'Cubic Metre per Hour', 'm^3/h'],
+      ['VolumetricFlowRate', 'Cubic Metre per Day', 'm^3/d']
+    ];
+    describe.each(si)('of type %s with unit %s and symbol %s', (type, unit, symbol) => {
+      it('doesn\'t throw Qty.Error.', () => {
+        expect(() => Quantity('1 ' + symbol)).not.toThrowError(Qty.Error);
+      });
+      it('returns a Quantity.', () => {
+        expect(Quantity('1' + symbol) instanceof Qty).toBe(true);
+      });
+    });
+  });
+});

--- a/types/openhab-js.d.ts
+++ b/types/openhab-js.d.ts
@@ -35,4 +35,5 @@ export const utils: typeof import("./utils");
 export const osgi: typeof import("./osgi");
 export const cache: typeof import("./cache");
 export const time: typeof import("./time");
+export const Quantity: typeof import("js-quantities");
 export {};


### PR DESCRIPTION
Replaced by #206.

Fixes #102.
Closes #200.
Fixes https://github.com/openhab/openhab-webui/issues/836.

## Description

This PR adds the fantastic [js-quantities](https://www.npmjs.com/package/js-quantities) library to provide easy `QuantityType` handling and unit conversions.

Given the [openHAB UoM Docs](https://next.openhab.org/docs/concepts/units-of-measurement.html#list-of-units), I have created unit tests to check compatibility of all base units from openHAB with the js-quantities library.

After polyfilling support for some additional unit notations (e.g. 'Ws' is `W*s`) and four units (see https://github.com/florian-h05/openhab-js/blob/js-quantities/quantities.js, the required math is linked), the new `Quantity` namespace is able to handle all units from openHAB except octet for data amount and mired for Temperature.

FYI: The addition of this increases the bundle site from 857KB to 932KB, which is minimal given the advantage of having the library and it's functionality. js-quantities has **no** dependencies.

I will add the docs in a follow-up PR.

## Testing

The additional units I've added are tested by unit tests as well to verify that they work mathematically correct.

/ping @stefan-hoehn @rkoshak @digitaldan 

@digitaldan @jpg0  I would like to get your opinion on the addition of such a library and possibly also some review, there is not much to review. The real code is just 60 lines.