### PR TITLE
[time] Add `isBetweenDates` & `isBetweenDateTimes` polyfills to `ZonedDateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## to be released
 
-| Type        | Namespace  | Description                                              | Reference                                              | Breaking |
-|-------------|------------|----------------------------------------------------------|--------------------------------------------------------|----------|
-| Enhancement | `triggers` | Add support for `Item` as argument & Add arg type checks | [#194](https://github.com/openhab/openhab-js/pull/194) | No       |
-| Enhancement | `items`    | ItemHistory: Add new persistence methods                 | [#196](https://github.com/openhab/openhab-js/pull/196) | No       |
-| Enhancement | `rules`    | Display `execute` code of `JSRule` in MainUI             | [#199](https://github.com/openhab/openhab-js/pull/199) | No       |
-| Enhancement | `time`     | Support ISO8601 string parsing in `toZDT`                | [#202](https://github.com/openhab/openhab-js/pull/202) | No       |
+| Type        | Namespace  | Description                                                              | Reference                                              | Breaking |
+|-------------|------------|--------------------------------------------------------------------------|--------------------------------------------------------|----------|
+| Enhancement | `triggers` | Add support for `Item` as argument & Add arg type checks                 | [#194](https://github.com/openhab/openhab-js/pull/194) | No       |
+| Enhancement | `items`    | ItemHistory: Add new persistence methods                                 | [#196](https://github.com/openhab/openhab-js/pull/196) | No       |
+| Enhancement | `rules`    | Display `execute` code of `JSRule` in MainUI                             | [#199](https://github.com/openhab/openhab-js/pull/199) | No       |
+| Enhancement | `time`     | Support ISO8601 string parsing in `toZDT`                                | [#202](https://github.com/openhab/openhab-js/pull/202) | No       |
+| Enhancement | `time`     | Add `isBetweenDates` & `isBetweenDateTimes` polyfills to `ZonedDateTime` | [#203](https://github.com/openhab/openhab-js/pull/203) | No       |
 
 Also see the [Release Milestone](https://github.com/openhab/openhab-js/milestone/10).
 

--- a/README.md
+++ b/README.md
@@ -820,6 +820,29 @@ time.toZDT().isBetweenTimes(items.getItem('Sunset'), '11:30 PM') // is now betwe
 time.toZDT(items.getItem('StartTime')).isBetweenTimes(time.toZDT(), 'PT1H'); // is the state of StartTime between now and one hour from now
 ```
 
+#### `isBetweenDates(start, end)`
+
+Tests whether this `time.ZonedDateTime` is between the passed in `start` and `end`.
+However, the function only compares the date portion of the three, ignoring the time portion.
+`start` and `end` can be anything supported by `time.toZDT()`.
+
+Examples:
+
+```javascript
+time.toZDT().isBetweenDates('2022-06-18', '2023-12-24') // currently between 2022-06-18 and 2023-12-24
+```
+
+#### `isBetweenDateTimes(start, end)`
+
+Tests whether this `time.ZonedDateTime` is between the passed in `start` and `end`.
+`start` and `end` can be anything supported by `time.toZDT()`.
+
+Examples:
+
+```javascript
+time.toZDT().isBetweenDateTimes('2022-06-18T22:00Z', '2023-12-24T05:00Z') // currently between 2022-06-18 22:00 and 2023-12-24 05:00
+```
+
 #### `isClose(zdt, maxDur)`
 
 Tests to see if the delta between the `time.ZonedDateTime` and the passed in `time.ZonedDateTime` is within the passed in `time.Duration`.

--- a/time.js
+++ b/time.js
@@ -163,7 +163,6 @@ const parseString = function (str) {
  * @throws error if the Item's state is not supported or the Item itself is not supported
  */
 const convertItem = function (item) {
-  // Uninitialized
   if (item.isUninitialized) {
     throw Error('Item ' + item.name + ' is NULL or UNDEF, cannot convert to a time.ZonedDateTime');
   } else if (item.rawState instanceof DecimalType) { // Number type Items
@@ -212,14 +211,9 @@ const toZDT = function (when) {
     return when;
   }
 
-  // Java ZDT
-  if (when instanceof javaZDT) {
-    return javaZDTtoZDT(when);
-  }
-
-  // DateTimeType, extract the javaZDT and convert to time.ZDT
-  if (when instanceof DateTimeType) {
-    return javaZDTtoZDT(when.getZonedDateTime());
+  // String or StringType
+  if (typeof when === 'string' || when instanceof javaString || when instanceof StringType) {
+    return parseString(when.toString());
   }
 
   // JavaScript Native Date, use the SYSTEM timezone
@@ -239,6 +233,16 @@ const toZDT = function (when) {
     return addMillisToNow(when);
   }
 
+  // Java ZDT
+  if (when instanceof javaZDT) {
+    return javaZDTtoZDT(when);
+  }
+
+  // DateTimeType, extract the javaZDT and convert to time.ZDT
+  if (when instanceof DateTimeType) {
+    return javaZDTtoZDT(when.getZonedDateTime());
+  }
+
   // QuantityType<Time>, add to now
   if (when instanceof QuantityType) {
     return addQuantityType(when);
@@ -247,11 +251,6 @@ const toZDT = function (when) {
   // Java Number of DecimalType, add as millisecs to now
   if (when instanceof javaNumber || when instanceof DecimalType) {
     return addMillisToNow(when.floatValue());
-  }
-
-  // String or StringType
-  if (typeof when === 'string' || when instanceof javaString || when instanceof StringType) {
-    return parseString(when.toString());
   }
 
   // GenericItem
@@ -277,8 +276,8 @@ time.ZonedDateTime.prototype.parse = function (text, formatter = rfcFormatter) {
 
 /**
  * Moves the date portion of the date time to today, accounting for DST
- * @memberof time
- * @returns {time.ZonedDateTime} a new date time with today's date
+ *
+ * @returns {time.ZonedDateTime} a new {@link time.ZonedDateTime} with today's date
  */
 time.ZonedDateTime.prototype.toToday = function () {
   const now = time.ZonedDateTime.now();
@@ -355,7 +354,6 @@ time.ZonedDateTime.prototype.isClose = function (zdt, maxDur) {
 /**
  * Parses a ZonedDateTime to milliseconds from now until the ZonedDateTime.
  *
- * @memberof time
  * @returns {number} duration from now to the ZonedDateTime in milliseconds
  */
 time.ZonedDateTime.prototype.getMillisFromNow = function () {

--- a/time.js
+++ b/time.js
@@ -288,25 +288,20 @@ time.ZonedDateTime.prototype.toToday = function () {
 };
 
 /**
- * Compares this ZDT to see if it falls between start and end times,
- * accounting for times that span midnight. start and end can be any type
- * that has a `toZonedDateTime()` method.
- * time.toZDT is called on the arguments. Examples:
+ * Tests whether `this` time.ZonedDateTime is between the passed in start and end.
+ * However, the function only compares the time portion of the three, ignoring the date portion.
+ * The function takes into account times that span midnight.
  *
- * time.ZonedDateTime.now().betweenTimes(items.getItem('Sunset'), "23:30:00") // is now between sunset and 11:00 pm?
- * time.toZDT(items.geItem('MyDateTimeItem')).betweenTimes(time.toZDT(), time.toZDT(1000)) // is the state of MyDateTimeItem between now and a second from now?
- * @memberof time
- * @param {*} start the starting time in anything that can be
- * @param {*} end the ending time
- * @returns {boolean} true if this is between start and end
+ * @param {*} start starting time, anything supported by {@link time.toZDT}
+ * @param {*} end ending time, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is between start and end
  */
 time.ZonedDateTime.prototype.isBetweenTimes = function (start, end) {
   const startTime = toZDT(start).toLocalTime();
   const endTime = toZDT(end).toLocalTime();
   const currTime = this.toLocalTime();
 
-  // time range spans midnight
-  if (endTime.isBefore(startTime)) {
+  if (endTime.isBefore(startTime)) { // Time range spans midnight
     return currTime.isAfter(startTime) || currTime.isBefore(endTime);
   } else {
     return currTime.isAfter(startTime) && currTime.isBefore(endTime);
@@ -314,9 +309,40 @@ time.ZonedDateTime.prototype.isBetweenTimes = function (start, end) {
 };
 
 /**
+ * Tests whether `this` time.ZonedDateTime is between the passed in start and end.
+ * However, the function only compares the date portion of the three, ignoring the time portion.
+ *
+ * @param {*} start starting date, anything supported by {@link time.toZDT}
+ * @param {*} end ending date, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is between start and end
+ */
+time.ZonedDateTime.prototype.isBetweenDates = function (start, end) {
+  const startDate = toZDT(start).toLocalDate();
+  const endDate = toZDT(end).toLocalDate();
+  const currDate = this.toLocalDate();
+
+  return currDate.isAfter(startDate) && currDate.isBefore(endDate);
+};
+
+/**
+ * Tests whether `this` time.ZonedDateTime is between the passed in start and end.
+ *
+ * @param {*} start starting DateTime, anything supported by {@link time.toZDT}
+ * @param {*} end ending DateTime, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is between start and end
+ */
+time.ZonedDateTime.prototype.isBetweenDateTimes = function (start, end) {
+  const startDateTime = toZDT(start).toLocalDateTime();
+  const endDateTime = toZDT(end).toLocalDateTime();
+  const currDateTime = this.toLocalDateTime();
+
+  return currDateTime.isAfter(startDateTime) && currDateTime.isBefore(endDateTime);
+};
+
+/**
  * Tests to see if the difference between this and the passed in ZoneDateTime is
  * within the passed in maxDur.
- * @memberof time
+ *
  * @param {time.ZonedDateTime} zdt the date time to compare to this
  * @param {time.Duration} maxDur the duration to test that the difference between this and zdt is within
  * @returns {boolean} true if the delta between this and zdt is within maxDur


### PR DESCRIPTION
Required for https://github.com/openhab/openhab-webui/issues/1597.

This extends our polyfills for `time.ZonedDateTime` with `isBetweenDates` and `isBetweenDateTimes` to complete `isBetweenTimes`.

@digitaldan Please especially review https://github.com/openhab/openhab-js/commit/f2d6982be3fa5d21d0e6d3943ced62920db4d9f8, the rest is just some reordering to allow some unit tests for `toZDT`.
@rkoshak I would also take a review of you, since you originally authored most parts or the time namespace.

The new methods and all polyfills in general are now testes by the unit tests.