### PR TITLE
Update bundling mechanism for globals injection caching

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,10 @@
 # WARNING: Please keep in mind that npm disregards .gitignore when there is a .npmignore file!
 
+@openhab-globals.js
 .github
-.vscode
 .idea
+.markdownlint.yaml
+.vscode
 coverage
 DEPLOY.md
 doc
@@ -14,4 +16,4 @@ jest.config.js
 openhab-*.tgz
 out
 test
-.markdownlint.yaml
+

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 # WARNING: Please keep in mind that npm disregards .gitignore when there is a .npmignore file!
 
-@openhab-globals.js
 .github
 .idea
 .markdownlint.yaml

--- a/@openhab-globals.js
+++ b/@openhab-globals.js
@@ -1,0 +1,8 @@
+// Injection of openhab-js namespaces as globals inside the addon
+
+(function (global) {
+  'use strict';
+  Object.assign(globalThis, require('./index'));
+  // Support legacy NodeJS libraries
+  globalThis.global = globalThis;
+})(this);

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,18 +2,18 @@
 
 ## Webpack
 
-openhab-js can be compiled into a single JS file, which is connivent for deploying locally and also how we ship the library with the JS Scripting binding in openHAB.
+openhab-js and it's injection script can be compiled into a single JS file, which is how we ship the library with the JS Scripting automation addon in openHAB.
 
 ```bash
 npm run webpack
 ```
 
-This outputs the library as a single JS file to `dist/openhab.js`.
+This outputs the library, and it's injection script as a single JS file to `dist/@openhab-globals.js`.
 
 ## TypeScript type definitions
 
 openhab-js has included type definitions which are generated from JSDoc using the [`typescript`](https://www.npmjs.com/package/typescript) npm module.
-Type definitons allow supercharged auto-completion in your IDE.
+Type definitions allow supercharged auto-completion in your IDE.
 
 ```bash
 npm run types

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,13 @@
 const path = require('path');
 
 module.exports = {
-  entry: './index.js',
-  mode: 'development',
+  entry: './@openhab-globals.js',
+  mode: 'production',
+  performance: {
+    hints: false,
+    maxEntrypointSize: 512000,
+    maxAssetSize: 512000
+  },
   externals: [
     {
       '@runtime': {
@@ -45,9 +50,9 @@ module.exports = {
   ],
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'openhab.js',
+    filename: '@openhab-globals.js',
     library: {
-      name: 'openhab',
+      name: '@openhab-globals',
       type: 'umd'
     },
     globalObject: 'this'


### PR DESCRIPTION
This contains the required changes for the openhab-js injection caching inside the JS Scripting addon in https://github.com/openhab/openhab-addons/pull/14135.

## Description

- Add injection script
- Modify webpack to bundle the library with the injection script as entrypoint
- Set webpack mode to production (now the bundle size is only about 450 KB, before it was about 900 KB)