### PR TITLE
[time] Add isBefore*/isAfter* convenience methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 | Bugfix      | `actions` & `triggers` | Remove arg type checks as they cause trouble & addon now logs stack on `IllegalArgumentException` | Commit [9975507](https://github.com/openhab/openhab-js/commit/99755070df9b4fa3d96157f74bbeb3809ae22514) | No       |
 | Bugfix      | `rules`                | `SwitchableJSRule`: Fix deprecation warning of EventObj                                           | Commit [0df9462](https://github.com/openhab/openhab-js/commit/0df946213a0ebf17f4ec4cec3ea12b6d08a483c8) | No       |
 | Bugfix      | `items`                | Metadata: Return configuration as JS obj instead of Java Map                                      | [#222](https://github.com/openhab/openhab-js/pull/222)                                                  | No       |
+| Enhancement | `time`                 | Add isBefore[Date|Time|DateTime] and isAfter[Date|Time|DateTime] methods to ZonedDateTime         | [#227](https://github.com/openhab/openhab-js/pull/227)                                                  | No       |
 
 Also see the [Release Milestone](https://github.com/openhab/openhab-js/milestone/11).
 

--- a/README.md
+++ b/README.md
@@ -796,6 +796,36 @@ var alarm = items.getItem('Alarm');
 alarm.postUpdate(time.toZDT(alarm).toToday());
 ```
 
+#### `isBeforeTime(timestamp)`, `isBeforeDate(timestamp)`, `isBeforeDateTime(timestamp)`
+
+Tests whether this `time.ZonedDateTime` is before the time passed in `timestamp`, tested in various ways:
+- `isBeforeTime` only compares the time portion of both, ignoring the date portion
+- `isBeforeDate` only compares the date portion of both, ignoring the time portion
+- `isBeforeDateTime` compares both date and time portions
+
+`timestamp` can be anything supported by `time.toZDT()`.
+
+Examples:
+
+```javascript
+time.toZDT('22:00').isBeforeTime('23:00')
+time.toZDT('2022-12-01T12:00Z').isBeforeDateTime('2022-12-02T13:00Z')
+```
+
+#### `isAfterTime(timestamp)`, `isAfterDate(timestamp)`, `isAfterDateTime(timestamp)`
+
+Tests whether this `time.ZonedDateTime` is after the time passed in `timestamp`, tested in various ways:
+- `isBeforeTime` only compares the time portion of both, ignoring the date portion
+- `isBeforeDate` only compares the date portion of both, ignoring the time portion
+- `isBeforeDateTime` compares both date and time portions
+
+`timestamp` can be anything supported by `time.toZDT()`.
+
+```javascript
+time.toZDT().isAfterTime(items.getItem('Sunset')) // is now after sunset?
+time.toZDT().isAfterDateTime('2022-12-01T12:00Z') // is now after 2022-12-01 noon?
+```
+
 #### `isBetweenTimes(start, end)`
 
 Tests whether this `time.ZonedDateTime` is between the passed in `start` and `end`.

--- a/README.md
+++ b/README.md
@@ -815,9 +815,9 @@ time.toZDT('2022-12-01T12:00Z').isBeforeDateTime('2022-12-02T13:00Z')
 #### `isAfterTime(timestamp)`, `isAfterDate(timestamp)`, `isAfterDateTime(timestamp)`
 
 Tests whether this `time.ZonedDateTime` is after the time passed in `timestamp`, tested in various ways:
-- `isBeforeTime` only compares the time portion of both, ignoring the date portion
-- `isBeforeDate` only compares the date portion of both, ignoring the time portion
-- `isBeforeDateTime` compares both date and time portions
+- `isAfterTime` only compares the time portion of both, ignoring the date portion
+- `isAfterDate` only compares the date portion of both, ignoring the time portion
+- `isAfterDateTime` compares both date and time portions
 
 `timestamp` can be anything supported by `time.toZDT()`.
 

--- a/README.md
+++ b/README.md
@@ -799,6 +799,7 @@ alarm.postUpdate(time.toZDT(alarm).toToday());
 #### `isBeforeTime(timestamp)`, `isBeforeDate(timestamp)`, `isBeforeDateTime(timestamp)`
 
 Tests whether this `time.ZonedDateTime` is before the time passed in `timestamp`, tested in various ways:
+
 - `isBeforeTime` only compares the time portion of both, ignoring the date portion
 - `isBeforeDate` only compares the date portion of both, ignoring the time portion
 - `isBeforeDateTime` compares both date and time portions
@@ -815,6 +816,7 @@ time.toZDT('2022-12-01T12:00Z').isBeforeDateTime('2022-12-02T13:00Z')
 #### `isAfterTime(timestamp)`, `isAfterDate(timestamp)`, `isAfterDateTime(timestamp)`
 
 Tests whether this `time.ZonedDateTime` is after the time passed in `timestamp`, tested in various ways:
+
 - `isAfterTime` only compares the time portion of both, ignoring the date portion
 - `isAfterDate` only compares the date portion of both, ignoring the time portion
 - `isAfterDateTime` compares both date and time portions

--- a/test/time.spec.js
+++ b/test/time.spec.js
@@ -104,6 +104,56 @@ describe('time.js', () => {
         expect(newZdt.toLocalDate().toString()).toBe(time.LocalDate.now().toString());
       });
 
+      describe('isBeforeTime and isAfterTime', () => {
+        const zdt1 = time.toZDT('14:30');
+        const zdt2 = time.toZDT('16:30');
+        it('returns true if before/after', () => {
+          expect(zdt1.isBeforeTime(zdt2)).toBe(true);
+          expect(zdt2.isAfterTime(zdt1)).toBe(true);
+        });
+        it('returns false if not before/after', () => {
+          expect(zdt2.isBeforeTime(zdt1)).toBe(false);
+          expect(zdt1.isBeforeTime(zdt1)).toBe(false);
+          expect(zdt1.isAfterTime(zdt2)).toBe(false);
+          expect(zdt1.isAfterTime(zdt1)).toBe(false);
+        });
+      });
+
+      describe('isBeforeDate and isAfterDate', () => {
+        const zdt1 = time.toZDT('2022-12-01');
+        const zdt2 = time.toZDT('2022-12-06');
+        it('returns true if before/after', () => {
+          expect(zdt1.isBeforeDate(zdt2)).toBe(true);
+          expect(zdt2.isAfterDate(zdt1)).toBe(true);
+        });
+        it('returns false if not before/after', () => {
+          expect(zdt2.isBeforeDate(zdt1)).toBe(false);
+          expect(zdt1.isBeforeDate(zdt1)).toBe(false);
+          expect(zdt1.isAfterDate(zdt2)).toBe(false);
+          expect(zdt1.isAfterDate(zdt1)).toBe(false);
+        });
+      });
+
+      describe('isBeforeDateTime and isAfterDateTime', () => {
+        const zdt1 = time.toZDT('2022-12-01T14:30Z');
+        const zdt2 = time.toZDT('2022-12-01T16:30Z');
+        const zdt3 = time.toZDT('2022-12-02T16:30Z');
+        it('returns true if before/after', () => {
+          expect(zdt1.isBeforeDateTime(zdt2)).toBe(true);
+          expect(zdt2.isBeforeDateTime(zdt3)).toBe(true);
+          expect(zdt2.isAfterDateTime(zdt1)).toBe(true);
+          expect(zdt3.isAfterDateTime(zdt2)).toBe(true);
+        });
+        it('returns false if not before/after', () => {
+          expect(zdt2.isBeforeDateTime(zdt1)).toBe(false);
+          expect(zdt3.isBeforeDateTime(zdt2)).toBe(false);
+          expect(zdt1.isBeforeDateTime(zdt1)).toBe(false);
+          expect(zdt1.isAfterDateTime(zdt2)).toBe(false);
+          expect(zdt2.isAfterDateTime(zdt3)).toBe(false);
+          expect(zdt1.isAfterDateTime(zdt1)).toBe(false);
+        });
+      });
+
       describe('isBetweenTimes', () => {
         const zdt1 = time.toZDT('14:30');
         const zdt2 = time.toZDT('16:30');

--- a/time.js
+++ b/time.js
@@ -301,6 +301,32 @@ time.ZonedDateTime.prototype.toToday = function () {
 };
 
 /**
+ * Tests whether `this` time.ZonedDateTime is before the passed in timestamp.
+ * However, the function only compares the time portion of both, ignoring the date portion.
+ *
+ * @param {*} timestamp Time for comparison, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is before timestamp
+ */
+time.ZonedDateTime.prototype.isBeforeTime = function (timestamp) {
+  const comparisonTime = toZDT(timestamp).toLocalTime();
+  const currTime = this.toLocalTime();
+  return currTime.isBefore(comparisonTime);
+};
+
+/**
+ * Tests whether `this` time.ZonedDateTime is after the passed in timestamp.
+ * However, the function only compares the time portion of both, ignoring the date portion.
+ *
+ * @param {*} timestamp Time for comparison, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is after timestamp
+ */
+time.ZonedDateTime.prototype.isAfterTime = function (timestamp) {
+  const comparisonTime = toZDT(timestamp).toLocalTime();
+  const currTime = this.toLocalTime();
+  return currTime.isAfter(comparisonTime);
+};
+
+/**
  * Tests whether `this` time.ZonedDateTime is between the passed in start and end.
  * However, the function only compares the time portion of the three, ignoring the date portion.
  * The function takes into account times that span midnight.
@@ -322,6 +348,32 @@ time.ZonedDateTime.prototype.isBetweenTimes = function (start, end) {
 };
 
 /**
+ * Tests whether `this` time.ZonedDateTime is before the passed in timestamp.
+ * However, the function only compares the date portion of both, ignoring the time portion.
+ *
+ * @param {*} timestamp Time for comparison, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is before timestamp
+ */
+time.ZonedDateTime.prototype.isBeforeDate = function (timestamp) {
+  const comparisonTime = toZDT(timestamp).toLocalDate();
+  const currTime = this.toLocalDate();
+  return currTime.isBefore(comparisonTime);
+};
+
+/**
+ * Tests whether `this` time.ZonedDateTime is after the passed in timestamp.
+ * However, the function only compares the date portion of both, ignoring the time portion.
+ *
+ * @param {*} timestamp Time for comparison, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is after timestamp
+ */
+time.ZonedDateTime.prototype.isAfterDate = function (timestamp) {
+  const comparisonTime = toZDT(timestamp).toLocalDate();
+  const currTime = this.toLocalDate();
+  return currTime.isAfter(comparisonTime);
+};
+
+/**
  * Tests whether `this` time.ZonedDateTime is between the passed in start and end.
  * However, the function only compares the date portion of the three, ignoring the time portion.
  *
@@ -335,6 +387,30 @@ time.ZonedDateTime.prototype.isBetweenDates = function (start, end) {
   const currDate = this.toLocalDate();
 
   return currDate.isAfter(startDate) && currDate.isBefore(endDate);
+};
+
+/**
+ * Tests whether `this` time.ZonedDateTime is before the passed in timestamp.
+ *
+ * @param {*} timestamp Time for comparison, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is before timestamp
+ */
+time.ZonedDateTime.prototype.isBeforeDateTime = function (timestamp) {
+  const comparisonTime = toZDT(timestamp).toLocalDateTime();
+  const currTime = this.toLocalDateTime();
+  return currTime.isBefore(comparisonTime);
+};
+
+/**
+ * Tests whether `this` time.ZonedDateTime is after the passed in timestamp.
+ *
+ * @param {*} timestamp Time for comparison, anything supported by {@link time.toZDT}
+ * @returns {boolean} true if `this` is after timestamp
+ */
+time.ZonedDateTime.prototype.isAfterDateTime = function (timestamp) {
+  const comparisonTime = toZDT(timestamp).toLocalDateTime();
+  const currTime = this.toLocalDateTime();
+  return currTime.isAfter(comparisonTime);
 };
 
 /**

--- a/time.js
+++ b/time.js
@@ -357,7 +357,7 @@ time.ZonedDateTime.prototype.isBetweenTimes = function (start, end) {
 time.ZonedDateTime.prototype.isBeforeDate = function (timestamp) {
   const comparisonDate = toZDT(timestamp).toLocalDate();
   const currDate = this.toLocalDate();
-  return currDate.isBefore(comparisonTime);
+  return currDate.isBefore(comparisonDate);
 };
 
 /**
@@ -370,7 +370,7 @@ time.ZonedDateTime.prototype.isBeforeDate = function (timestamp) {
 time.ZonedDateTime.prototype.isAfterDate = function (timestamp) {
   const comparisonDate = toZDT(timestamp).toLocalDate();
   const currDate = this.toLocalDate();
-  return currDate.isAfter(comparisonTime);
+  return currDate.isAfter(comparisonDate);
 };
 
 /**
@@ -398,7 +398,7 @@ time.ZonedDateTime.prototype.isBetweenDates = function (start, end) {
 time.ZonedDateTime.prototype.isBeforeDateTime = function (timestamp) {
   const comparisonDateTime = toZDT(timestamp).toLocalDateTime();
   const currDateTime = this.toLocalDateTime();
-  return currDateTime.isBefore(comparisonTime);
+  return currDateTime.isBefore(comparisonDateTime);
 };
 
 /**
@@ -410,7 +410,7 @@ time.ZonedDateTime.prototype.isBeforeDateTime = function (timestamp) {
 time.ZonedDateTime.prototype.isAfterDateTime = function (timestamp) {
   const comparisonDateTime = toZDT(timestamp).toLocalDateTime();
   const currDateTime = this.toLocalDateTime();
-  return currDateTime.isAfter(comparisonTime);
+  return currDateTime.isAfter(comparisonDateTime);
 };
 
 /**

--- a/time.js
+++ b/time.js
@@ -355,9 +355,9 @@ time.ZonedDateTime.prototype.isBetweenTimes = function (start, end) {
  * @returns {boolean} true if `this` is before timestamp
  */
 time.ZonedDateTime.prototype.isBeforeDate = function (timestamp) {
-  const comparisonTime = toZDT(timestamp).toLocalDate();
-  const currTime = this.toLocalDate();
-  return currTime.isBefore(comparisonTime);
+  const comparisonDate = toZDT(timestamp).toLocalDate();
+  const currDate = this.toLocalDate();
+  return currDate.isBefore(comparisonTime);
 };
 
 /**
@@ -368,9 +368,9 @@ time.ZonedDateTime.prototype.isBeforeDate = function (timestamp) {
  * @returns {boolean} true if `this` is after timestamp
  */
 time.ZonedDateTime.prototype.isAfterDate = function (timestamp) {
-  const comparisonTime = toZDT(timestamp).toLocalDate();
-  const currTime = this.toLocalDate();
-  return currTime.isAfter(comparisonTime);
+  const comparisonDate = toZDT(timestamp).toLocalDate();
+  const currDate = this.toLocalDate();
+  return currDate.isAfter(comparisonTime);
 };
 
 /**
@@ -396,9 +396,9 @@ time.ZonedDateTime.prototype.isBetweenDates = function (start, end) {
  * @returns {boolean} true if `this` is before timestamp
  */
 time.ZonedDateTime.prototype.isBeforeDateTime = function (timestamp) {
-  const comparisonTime = toZDT(timestamp).toLocalDateTime();
-  const currTime = this.toLocalDateTime();
-  return currTime.isBefore(comparisonTime);
+  const comparisonDateTime = toZDT(timestamp).toLocalDateTime();
+  const currDateTime = this.toLocalDateTime();
+  return currDateTime.isBefore(comparisonTime);
 };
 
 /**
@@ -408,9 +408,9 @@ time.ZonedDateTime.prototype.isBeforeDateTime = function (timestamp) {
  * @returns {boolean} true if `this` is after timestamp
  */
 time.ZonedDateTime.prototype.isAfterDateTime = function (timestamp) {
-  const comparisonTime = toZDT(timestamp).toLocalDateTime();
-  const currTime = this.toLocalDateTime();
-  return currTime.isAfter(comparisonTime);
+  const comparisonDateTime = toZDT(timestamp).toLocalDateTime();
+  const currDateTime = this.toLocalDateTime();
+  return currDateTime.isAfter(comparisonTime);
 };
 
 /**


### PR DESCRIPTION
Provide isBefore[Date|Time|DateTime] and isAfter[Date|Time|DateTime] methods for symmetry to the isBetween[Dates|Times|DateTimes] methods.

Fixes #224
