### PR TITLE
fix executeCommandLine without a Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,16 +582,14 @@ See [openhab-js : actions.Exec](https://openhab.github.io/openhab-js/actions.htm
 Execute a command line.
 
 ```javascript
-
 // Execute command line.
 actions.Exec.executeCommandLine('echo', 'Hello World!');
 
 // Execute command line with timeout.
-var Duration = Java.type('java.time.Duration');
 actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello World!');
 
 // Get response from command line with timeout.
-response = actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello World!');
+var response = actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello World!');
 ```
 
 #### HTTP Actions

--- a/README.md
+++ b/README.md
@@ -588,13 +588,10 @@ actions.Exec.executeCommandLine('echo', 'Hello World!');
 
 // Execute command line with timeout.
 var Duration = Java.type('java.time.Duration');
-actions.Exec.executeCommandLine(Duration.ofSeconds(20), 'echo', 'Hello World!');
-
-// Get response from command line.
-var response = actions.Exec.executeCommandLine('echo', 'Hello World!');
+actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello World!');
 
 // Get response from command line with timeout.
-response = actions.Exec.executeCommandLine(Duration.ofSeconds(20), 'echo', 'Hello World!');
+response = actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello World!');
 ```
 
 #### HTTP Actions


### PR DESCRIPTION
Without a `Duration` argument, `executeCommandLine` always returns `null`. I removed the example that appears to show calling it without a `Duration` and getting the result of the echo.  That can't happen as it's currently implemented.

Also, we need to use `time.Duration` right? I'm pretty sure that's the case. If I'm wrong and that's not the case, we should show importing java.time.Duration in the example.

I think I forgot to sign off on this. This is really minor doc update, I hope the exception can apply. If not I'll figure out how to fix it. 
