### PR TITLE
[osgi] Migrate from addon to core lifecycle tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 | Enhancement | `items`                | Allow Item lookup by name directly on the `items` namespace                                       | [#233](https://github.com/openhab/openhab-js/pull/233)                                                  | No       |
 | Enhancement | `items`                | Add `numericState` & `quantityState` properties to `Item` & `HistoricItem`                        | [#234](https://github.com/openhab/openhab-js/pull/234)                                                  | No       |
 | Enhancement | `items`                | Extend `metadata` & `itemchannellink` methods with additional functionality                       | [#223](https://github.com/openhab/openhab-js/pull/223)                                                  | No       |
+| Enhancement | `osgi`                 | Migrate from addon- to core-provided lifecycle tracker                                            | [#237](https://github.com/openhab/openhab-js/pull/237)                                                  | No       |
 
 Also see the [Release Milestone](https://github.com/openhab/openhab-js/milestone/11).
 

--- a/osgi.js
+++ b/osgi.js
@@ -6,7 +6,7 @@
  */
 const log = require('./log')('osgi');
 const bundleContext = require('@runtime/osgi').bundleContext;
-const lifecycle = require('@runtime/osgi').lifecycle;
+const lifecycleTracker = require('@runtime').lifecycleTracker;
 const Hashtable = Java.type('java.util.Hashtable');
 
 /**
@@ -93,7 +93,7 @@ const findServices = function (className, filter) {
 };
 
 const registerService = function (service, ...interfaceNames) {
-  lifecycle.addDisposeHook(() => unregisterService(service));
+  lifecycleTracker.addDisposeHook(() => unregisterService(service));
   registerPermanentService(service, interfaceNames, null);
 };
 

--- a/test/@runtime.mock.js
+++ b/test/@runtime.mock.js
@@ -2,7 +2,10 @@ jest.mock('@runtime', () => ({
   DateTimeType: jest.fn(),
   DecimalType: jest.fn(),
   StringType: jest.fn(),
-  QuantityType: jest.fn()
+  QuantityType: jest.fn(),
+  lifecycleTracker: {
+    addDisposeHook: jest.fn()
+  }
 }), { virtual: true });
 
 jest.mock('@runtime/Defaults', () => ({}), { virtual: true });
@@ -13,8 +16,5 @@ jest.mock('@runtime/osgi', () => ({
     getService: jest.fn(),
     getAllServiceReferences: jest.fn(),
     registerService: jest.fn()
-  },
-  lifecycle: {
-    addDisposeHook: jest.fn()
   }
 }), { virtual: true });

--- a/test/osgi.spec.js
+++ b/test/osgi.spec.js
@@ -1,7 +1,7 @@
 const { getService, findServices, unregisterService, registerPermanentService, registerService } = require('../osgi');
 const { Hashtable } = require('./java.mock');
 const bundleContext = require('@runtime/osgi').bundleContext;
-const lifecycle = require('@runtime/osgi').lifecycle;
+const lifecycleTracker = require('@runtime').lifecycleTracker;
 
 describe('osgi.js', () => {
   describe('getService', () => {
@@ -162,7 +162,7 @@ describe('osgi.js', () => {
 
       registerService(service, ...interfaceNames);
 
-      expect(lifecycle.addDisposeHook).toHaveBeenCalled();
+      expect(lifecycleTracker.addDisposeHook).toHaveBeenCalled();
     });
 
     it('regsiters given service.', () => {


### PR DESCRIPTION
This replaces the addon lifecycle tracker through the one provided by openHAB core. Since the core lifecycle tracker is in place since March 2020 and therefore openHAB 3.1.0, we can safely switch to the core version.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>