### PR TITLE
[rules] Adjust event object for recent core changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## to be released
 
-| Type        | Namespace  | Description                                                    | Reference                                                                                        | Breaking |
-|-------------|------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------------------|----------|
+| Type        | Namespace  | Description                                                    | Reference                                              | Breaking |
+|-------------|------------|----------------------------------------------------------------|--------------------------------------------------------|----------|
+| Bugfix      | `rules`    | Adjust `event` object for recent core changes                  | [#260](https://github.com/openhab/openhab-js/pull/260) | No       |
 
 Also see the [Release Milestone](https://github.com/openhab/openhab-js/milestone/14).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 Also see the [Release Milestone](https://github.com/openhab/openhab-js/milestone/14).
 
+Please note that openHAB >= 4.0.0(.M2) (or >= `SNAPSHOT #3391`) requires at least this version.
+
 ## 4.2.0
 
 | Type        | Namespace  | Description                                                    | Reference                                                                                        | Breaking |

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ This will be used instead of the binding provided version.
 
 ## Compatibility
 
-All `openhab-js` versions (latest is `4.1.0` as of writing) are fully compatible with openHAB 3.1.0 or newer.
+All `openhab-js` versions (latest is `4.2.1` as of writing) are fully compatible with openHAB 3.1.0 or newer.
+
 openHAB 3.4.0 or newer requires at least `openhab-js` 3.1.0!
+openHAB 4.0.0(.M2) (or >= `SNAPSHOT #3391`) or newer requires at least `openhab-js` 4.2.1!
 
 ## Configuration
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -380,6 +380,9 @@ const _getTriggeredData = function (input) {
         data.eventType = 'change';
         data.triggerType = 'ItemStateChangeTrigger';
         break;
+      case 'org.openhab.core.items.events.ItemStateUpdatedEvent':
+      case 'org.openhab.core.items.events.GroupStateUpdatedEvent':
+      // **StateEvents replaced by **StateUpdatedEvents in https://github.com/openhab/openhab-core/pull/3141
       case 'org.openhab.core.items.events.GroupItemStateEvent':
       case 'org.openhab.core.items.events.ItemStateEvent':
         data.itemName = event.getItemName();

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -380,9 +380,9 @@ const _getTriggeredData = function (input) {
         data.eventType = 'change';
         data.triggerType = 'ItemStateChangeTrigger';
         break;
+      // **StateEvents replaced by **StateUpdatedEvents in https://github.com/openhab/openhab-core/pull/3141
       case 'org.openhab.core.items.events.ItemStateUpdatedEvent':
       case 'org.openhab.core.items.events.GroupStateUpdatedEvent':
-      // **StateEvents replaced by **StateUpdatedEvents in https://github.com/openhab/openhab-core/pull/3141
       case 'org.openhab.core.items.events.GroupItemStateEvent':
       case 'org.openhab.core.items.events.ItemStateEvent':
         data.itemName = event.getItemName();


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/3141 changed the events that are passed to the rule for **StateUpdateTriggers. This adds support for the changed classnames whilst keeping backward compatibility.