### PR TITLE
[rules] Preserve disabled state of switchable rules after restarting

### DIFF
--- a/rules/rules.js
+++ b/rules/rules.js
@@ -324,6 +324,7 @@ function SwitchableJSRule (ruleConfig) {
       item.sendCommand('ON');
     }
   }
+
   RuleManager.setEnabled(rule.getUID(), item.state !== 'OFF');
 }
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -324,7 +324,6 @@ function SwitchableJSRule (ruleConfig) {
       item.sendCommand('ON');
     }
   }
- 
   RuleManager.setEnabled(rule.getUID(), item.state !== 'OFF');
 }
 

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -324,6 +324,8 @@ function SwitchableJSRule (ruleConfig) {
       item.sendCommand('ON');
     }
   }
+ 
+  RuleManager.setEnabled(rule.getUID(), item.state !== 'OFF');
 }
 
 /**


### PR DESCRIPTION
When a `SwitchableJSRule` has been switched off and I change something in my script so that it restarts, then after recreation of the rules the switch item would correctly be in `OFF` state given its historical state, but the rule it represents would still be enabled. Which basically means whenever your script restarts, all previously disabled rules would get enabled, without noticing...

This should fix it, tested locally.