### PR TITLE
Infrastructure: Disable Webpack TerserPlugin for cached globals injection

### DIFF
--- a/build/@globals-webpack.config.js
+++ b/build/@globals-webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     maxEntrypointSize: 512000,
     maxAssetSize: 512000
   },
-  // Do NOT set up "minimize" using "TerserPlugin", as this heavily decreased performance for the cached version
+  // Do NOT set up "minimize" using "TerserPlugin", as this (very) negatively affects performance for the cached version
   externals: [
     {
       '@runtime': {

--- a/build/@globals-webpack.config.js
+++ b/build/@globals-webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
   entry: './build/@openhab-globals.js',
@@ -9,17 +8,7 @@ module.exports = {
     maxEntrypointSize: 512000,
     maxAssetSize: 512000
   },
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          keep_classnames: true,
-          keep_fnames: true
-        }
-      })
-    ]
-  },
+  // Do NOT set up "minimize" using "TerserPlugin", as this heavily decreased performance for the cached version
   externals: [
     {
       '@runtime': {


### PR DESCRIPTION
Regression from #273.

Using the Webpack TerserPlugin to minimize web-packed, cached globals injection heavily decreased performance, therefore remove it.