### PR TITLE
Ignore more IDE generated files with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 .DS_Store
-.vscode
 .idea
+.project
+.settings
+.vscode
 dist
 docs
 node_modules
 openhab-*.tgz
 out
+*.iml
 test/coverage
 types/@globals-webpack.config.*
 types/@openhab-globals.*


### PR DESCRIPTION
These unwanted files are also often generated when creating projects in Eclipse and IntelliJ IDEA.