### PR TITLE
[actions] Code clean-up for ScriptExecution.createTimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ This will be used instead of the binding provided version.
 ## Compatibility
 
 All `openhab-js` versions until 4.7.0 are fully compatible with openHAB 3.1.0 or newer!
+
 `openhab-js` 4.7.1 or newer requires openHAB 4.1.1 or newer for full compatibility!
+`actions.ScriptExecution.createTimer` and type conversion when passing `Quantity` to a Java method expecting a `QuantityType` are known to not work.
 
 openHAB 3.4.0 or newer requires at least `openhab-js` 3.1.0!
 openHAB 4.0.0(.M2) (or >= `SNAPSHOT #3391`) or newer requires at least `openhab-js` 4.2.1!

--- a/actions.js
+++ b/actions.js
@@ -265,20 +265,10 @@ class ScriptExecution {
     // Support method overloading as identifier is optional
     if (typeof identifier === 'string' && functionRef != null) {
       const callbackFn = () => functionRef(...params);
-      // Try to access the createTimer method of ThreadsafeTimers
-      try {
-        return ThreadsafeTimers.createTimer(identifier, zdt, callbackFn); // eslint-disable-line no-undef
-      } catch {
-        return JavaScriptExecution.createTimer(identifier, zdt, callbackFn);
-      }
+      return ThreadsafeTimers.createTimer(identifier, zdt, callbackFn); // eslint-disable-line no-undef
     } else {
       const callbackFn = () => zdt(functionRef, ...params);
-      // Try to access the createTimer method of ThreadsafeTimers
-      try {
-        return ThreadsafeTimers.createTimer(identifier, callbackFn); // eslint-disable-line no-undef
-      } catch {
-        return JavaScriptExecution.createTimer(identifier, callbackFn);
-      }
+      return ThreadsafeTimers.createTimer(identifier, callbackFn); // eslint-disable-line no-undef
     }
   }
 

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -41,26 +41,6 @@ describe('actions.js', () => {
       expect(ThreadsafeTimers.createTimer).toHaveBeenCalled();
       expect(JavaScriptExecution.callScript).not.toHaveBeenCalled();
     });
-
-    it('falls back to Java ScriptExecution, when ThreadsafeTimers throws error.', () => {
-      const identifier = 'timer-1';
-      const zdt = {};
-      const functionRef = (foo) => foo;
-
-      ThreadsafeTimers.createTimer.mockImplementation(() => { throw new Error(); });
-
-      ScriptExecution.createTimer(identifier, zdt, functionRef);
-
-      expect(ThreadsafeTimers.createTimer).toHaveBeenCalled();
-      expect(JavaScriptExecution.createTimer).toHaveBeenCalled();
-
-      jest.clearAllMocks();
-
-      ScriptExecution.createTimer(zdt, functionRef);
-
-      expect(ThreadsafeTimers.createTimer).toHaveBeenCalled();
-      expect(JavaScriptExecution.createTimer).toHaveBeenCalled();
-    });
   });
 
   describe('Transformation', () => {


### PR DESCRIPTION
Since the current library version is officially not supported on older openHAB versions, the fallback from ThreadsafeTimers to ScriptExecution actions can be removed.