### PR TITLE
README: Add JS-Joda locale installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete
 
 Occasionally, one will need to parse a non-supported date time string or generate one from a ZonedDateTime.
 To do this you will use [JS-Joda DateTimeFormatter and potentially your Locale](https://js-joda.github.io/js-joda/manual/formatting.html).
-However, all the locales combine to a unacceptibly large size to ship them with the openhab-js library.
+However, shipping all the locales with the openhab-js library would lead to an unacceptable large size.
 Therefore if you attempt to use the `DateTimeFormatter` and receive an error saying it cannot find your locale, you will need to manually install your locale and import it into your rule.
 
 [JS-Joda Locales](https://github.com/js-joda/js-joda/tree/master/packages/locale#use-prebuilt-locale-packages) includes a list of all the supported locales.

--- a/README.md
+++ b/README.md
@@ -829,6 +829,23 @@ actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello Worl
 
 See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete API usage.
 
+### Parsing and Formatting
+Occasionally, one will need to parse a non-supported date time string or generate one from a ZonedDateTime.
+To do this you will use [JS-Joda DateTimeFormatter and potentially your Locale](https://js-joda.github.io/js-joda/manual/formatting.html).
+However, all the locales combine to a unacceptibly large size to ship them with the openhab-js library.
+Therefore if you attempt to use the `DateTimeFormatter` and receive an error saying it cannot find your locale, you will need to install your locale and import it into your rule.
+
+[JS-Joda Locales](https://github.com/js-joda/js-joda/tree/master/packages/locale#use-prebuilt-locale-packages) includes a list of all the supported locales.
+Each loacle consists of a two letter language indicator followed by a "-" and a two letter dialect indicator: e.g. "EN-US".
+Installing a locale can be done through the command `npm install @js-joda/locale_de-de` from the *$OPENHAB_CONF/automation/js* folder.
+
+To import and use a local into your rule you need to require it and create a `DateTimeFormatter` that uses it.
+
+```javascript
+var Locale = require('@js-joda/locale_de-de').Locale.GERMAN;
+var formatter = time.DateTimeFormatter.ofPattern('MM/dd/yy HH:mm').withLocale(Locale);
+```
+
 #### `time.toZDT()`
 
 There will be times when this automatic conversion is not available (for example when working with date times within a rule).

--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello Worl
 See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete API usage.
 
 ### Parsing and Formatting
+
 Occasionally, one will need to parse a non-supported date time string or generate one from a ZonedDateTime.
 To do this you will use [JS-Joda DateTimeFormatter and potentially your Locale](https://js-joda.github.io/js-joda/manual/formatting.html).
 However, all the locales combine to a unacceptibly large size to ship them with the openhab-js library.

--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello Worl
 
 See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete API usage.
 
-### Parsing and Formatting
+#### Parsing and Formatting
 
 Occasionally, one will need to parse a non-supported date time string or generate one from a ZonedDateTime.
 To do this you will use [JS-Joda DateTimeFormatter and potentially your Locale](https://js-joda.github.io/js-joda/manual/formatting.html).

--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ To import and use a local into your rule you need to require it and create a `Da
 
 ```javascript
 var Locale = require('@js-joda/locale_de-de').Locale.GERMAN;
-var formatter = time.DateTimeFormatter.ofPattern('MM/dd/yy HH:mm').withLocale(Locale);
+var formatter = time.DateTimeFormatter.ofPattern('dd.MM.yyyy HH:mm').withLocale(Locale);
 ```
 
 #### `time.toZDT()`

--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete
 Occasionally, one will need to parse a non-supported date time string or generate one from a ZonedDateTime.
 To do this you will use [JS-Joda DateTimeFormatter and potentially your Locale](https://js-joda.github.io/js-joda/manual/formatting.html).
 However, all the locales combine to a unacceptibly large size to ship them with the openhab-js library.
-Therefore if you attempt to use the `DateTimeFormatter` and receive an error saying it cannot find your locale, you will need to install your locale and import it into your rule.
+Therefore if you attempt to use the `DateTimeFormatter` and receive an error saying it cannot find your locale, you will need to manually install your locale and import it into your rule.
 
 [JS-Joda Locales](https://github.com/js-joda/js-joda/tree/master/packages/locale#use-prebuilt-locale-packages) includes a list of all the supported locales.
 Each loacle consists of a two letter language indicator followed by a "-" and a two letter dialect indicator: e.g. "EN-US".

--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ Therefore if you attempt to use the `DateTimeFormatter` and receive an error say
 Each loacle consists of a two letter language indicator followed by a "-" and a two letter dialect indicator: e.g. "EN-US".
 Installing a locale can be done through the command `npm install @js-joda/locale_de-de` from the *$OPENHAB_CONF/automation/js* folder.
 
-To import and use a local into your rule you need to require it and create a `DateTimeFormatter` that uses it.
+To import and use a local into your rule you need to require it and create a `DateTimeFormatter` that uses it:
 
 ```javascript
 var Locale = require('@js-joda/locale_de-de').Locale.GERMAN;


### PR DESCRIPTION
Closes #54.

Adds a section that explains when one might need to install a JS-Joda locale, why, and how to install a locale, import and use it in a rule.