### PR TITLE
Update action-gh-pages in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Publish Docs
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
Updates the GitHub pages GitHub action to version 4. See https://github.com/peaceiris/actions-gh-pages/blob/v4.0.0/CHANGELOG.md#400-2024-04-08.