### PR TITLE
Improve build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - run: npm run deploy
+      - run: npm run build
 
       - name: Publish Docs
         if: github.ref == 'refs/heads/main'

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -33,7 +33,7 @@ We have a GitHub action which will publish this library automatically when a ver
 Use the [npm version](https://docs.npmjs.com/cli/v9/commands/npm-version) command to bump the version, commit and tag:
 
 ```bash
-npm run deploy # Perform tests, test JSDoc deployment, webpack build, update and test type definitions
+npm run build # Perform a local build: Lint, run tests, bundle with webpack, update & test type definitions, build JSDoc
 npm version [major | minor | patch] --no-git-tag-version # Select one of the commands
 ```
 

--- a/package.json
+++ b/package.json
@@ -17,16 +17,19 @@
         "parse-duration": "^0.1.1"
     },
     "scripts": {
-        "test:mocha": "mocha test/**/*.test.js",
-        "test:jest": "jest --config test/jest.config.js",
-        "test": "npm run lint && npm run test:mocha && npm run test:jest",
-        "docs": "rm -Rf ./docs/* && jsdoc --configure build/jsdoc.conf.json",
-        "deploy": "npm test && npm run docs && npm run webpack && npm run types && npm run types:test",
         "lint": "npx eslint src",
         "lint:fix": "npx eslint --fix src",
-        "webpack": "webpack -c build/webpack.config.js && webpack -c build/@globals-webpack.config.js",
+        "pretest": "npm run lint",
+        "test:mocha": "mocha test/**/*.test.js",
+        "test:jest": "jest --config test/jest.config.js",
+        "test": "npm run test:mocha && npm run test:jest",
         "types": "tsc --project ./build/tsconfig.json",
-        "types:test": "tsc --project ./build/tsconfig.test.json"
+        "types:test": "tsc --project ./build/tsconfig.test.json",
+        "webpack": "webpack -c build/webpack.config.js && webpack -c build/@globals-webpack.config.js",
+        "docs": "rm -Rf ./docs/* && jsdoc --configure build/jsdoc.conf.json",
+        "prebuild": "npm run test",
+        "build": "npm run webpack && npm run types && npm run types:test",
+        "postbuild": "npm run docs"
     },
     "devDependencies": {
         "@types/jest": "^29.5.12",


### PR DESCRIPTION
This re-orders the npm scripts and makes use of pre- and post- scripts to improve the structure of the build process.
Also rename the deploy script to build as this better reflects what it does.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com> 