### PR TITLE
README: Fix Item persistene reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ See [openhab-js : ItemConfig](https://openhab.github.io/openhab-js/global.html#I
 
 #### `ItemPersistence`
 
-Calling `Item.history` returns an `ItemPersistence` object with the following functions:
+Calling `Item.persistence` returns an `ItemPersistence` object with the following functions:
 
 - ItemPersistence :`object`
   - .averageSince(timestamp, serviceId) ⇒ `PersistedState | null`


### PR DESCRIPTION
The member was renamed from `history` in #331.

I tested if `history` is still available for backwards compatibility, but it appears not:
```javascript
var averageSpotPrice = items.Energi_Data_Service_Spot_Price.history.averageBetween(tomorrowPeakStart, tomorrowPeakEnd);
```

Result:
```
Failed to execute action: 1(Error: Failed to execute rule Test-persistence-00356c1b-7b21-4fc2-8789-9b804de7577f: TypeError: undefined has no such function "averageBetween": TypeError: undefined has no such function "averageBetween"
```