### PR TITLE
Markdown Checks: Upgrade actions & Ignore commit/PR links

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,9 +1,4 @@
-# From: https://github.com/openhab/openhab-docs/blob/main/.github/workflows/markdownlint.yml
-# From: https://github.com/openhab/openhab-docs/blob/main/.github/workflows/brokenLinkCheck.yml
-
 name: Check Markdown For Errors
-
-# https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
 
 on:
   push:
@@ -15,18 +10,21 @@ on:
 
 jobs:
   markdownlint:
+    name: markdownlint
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # pinning to SHA to mitigate possible supply chain attack
       - name: Run markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v3.2.0
+        uses: nosborn/github-action-markdown-cli@58bcfd1af530d87a13d51b76e6713b52602e3613 # v3.4.0
         with:
           files: .
           config_file: ".markdownlint.yaml"
 
   markdown-link-check:
-    name: Check for broken links
+    name: Broken Links Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -17,8 +17,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.2.0
         with:
@@ -29,5 +29,13 @@ jobs:
     name: Check for broken links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # pinning to SHA to mitigate possible supply chain attack
+      - name: Check for broken links
+        uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1.1.0
+        with:
+          use-quiet-mode: 'yes' # only show errors in output
+          use-verbose-mode: 'yes' # show detailed HTTP status for checked links
+          file-path: 'CONTRIBUTING.md, DEPLOY.md, README.md'

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -38,4 +38,4 @@ jobs:
         with:
           use-quiet-mode: 'yes' # only show errors in output
           use-verbose-mode: 'yes' # show detailed HTTP status for checked links
-          file-path: 'CONTRIBUTING.md, DEPLOY.md, README.md'
+          config-file: 'mlc_config.json'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ then you just add a line to every git commit message:
 
 using your real name (sorry, no pseudonyms or anonymous contributions.) and an
 e-mail address under which you can be reached (sorry, no GitHub no-reply e-mail
-addresses (such as username@users.noreply.github.com) or other non-reachable
+addresses (such as `username@users.noreply.github.com`) or other non-reachable
 addresses are allowed).
 
 On the command line you can use `git commit -s` to sign off the commit.

--- a/README.md
+++ b/README.md
@@ -911,7 +911,7 @@ You can work-around that limitation by either serialising and deserialising JS o
 Timers as created by [`createTimer`](#createtimer) can be stored in the shared cache.
 The ids of timers and intervals as created by `setTimeout` and `setInterval` cannot be shared across scripts as these ids are local to the script where they were created.
 
-See [openhab-js : cache](https://openha.github.io/openhab-js/cache.html) for full API documentation.
+See [openhab-js : cache](https://openhab.github.io/openhab-js/cache.html) for full API documentation.
 
 - cache : <code>object</code>
   - .private

--- a/README.md
+++ b/README.md
@@ -911,7 +911,7 @@ You can work-around that limitation by either serialising and deserialising JS o
 Timers as created by [`createTimer`](#createtimer) can be stored in the shared cache.
 The ids of timers and intervals as created by `setTimeout` and `setInterval` cannot be shared across scripts as these ids are local to the script where they were created.
 
-See [openhab-js : cache](https://openhab.github.io/openhab-js/cache.html) for full API documentation.
+See [openhab-js : cache](https://openha.github.io/openhab-js/cache.html) for full API documentation.
 
 - cache : <code>object</code>
   - .private

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
-    {
-      "pattern": "^https://github.com/openhab/openhab-js/commit/.*"
-    }
+    { "pattern": "^https://github.com/openhab/openhab-js/commit/.*" },
+    { "pattern": "^https://github.com/openhab/openhab-js/pull/.*" },
+    { "pattern": "^mailto:.*" }
   ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://github.com/openhab/openhab-js/commit/.*"
+    }
+  ]
+}


### PR DESCRIPTION
This updates the Markdown Broken Link Check to use tcort/github-action-markdown-link-check instead of the deprecated garauv-nelson/github-action-markdown-link-check and pins its version to a SHA to migitate possible supply chain attacks.
It also ignores commit/PR links for this repository.

This updates the markdownlint action and pins its version to a SHA.